### PR TITLE
move batching to preprocessor to prepare for seq parallel

### DIFF
--- a/conf/base.yaml
+++ b/conf/base.yaml
@@ -56,12 +56,13 @@ preprocess:
   raw_queue_size: 8
   input_queue_size: 32
   output_queue_size: 32
+  ring_buffer_size: 128
+  max_unconsumed_samples: 64
   chunk_n_groups: 2
   submit_delay: 0.
   pop_old_data: ${..pop_old_data} 
   buffer_size: 0
   shared_memory_entry_size: 100000000
-  max_unconsumed_samples: batch
 llm:
   parameters:
     # changed

--- a/conf/base.yaml
+++ b/conf/base.yaml
@@ -61,6 +61,7 @@ preprocess:
   pop_old_data: ${..pop_old_data} 
   buffer_size: 0
   shared_memory_entry_size: 100000000
+  max_unconsumed_samples: batch
 llm:
   parameters:
     # changed

--- a/conf/base.yaml
+++ b/conf/base.yaml
@@ -4,41 +4,6 @@ defaults:
   - streams: files
   - _self_
 
-finetune:
-  use_flash_attention: true
-  attn_implementation: flash_attention_2
-  config_name: ${..model_path}
-  output_dir: ${..output_dir}/finetune
-  seq_length: 12000
-  seq_packing: true
-  rl:
-    algo: reinforce
-    divide_advantage_by_std: false
-    kl_coef: 0.0
-    entropy_bonus: 0.0
-    reward_minus_kl_coef: 0.0
-    epsilon: 4
-    use_advantages: true
-    relu_log_p_weights: false
-    clamp_log_ratio_ref_new_value: 5
-    temperature: ${...llm.parameters.temperature}
-    aggregate_loss: sum
-  train_batch_size: 1
-  gradient_accumulation_passes: 1024
-  gradient_checkpointing: true
-  gradient_clipping_threshold: 0.3
-  # see https://medium.com/pytorch/how-activation-checkpointing-enables-scaling-up-training-deep-learning-models-7a93ae01ff2d
-  # for the motivation to this false by default
-  reentrant_checkpointing: false
-  learning_rate: 1e-6
-  save_checkpoint_steps: 100
-  log_each_n_steps: 1
-  input: training_data
-  send_weight_updates: true
-  queue_size: 32
-  max_lag: ${..max_lag}
-  weight_update_interval: 1
-  pop_old_data: ${..pop_old_data}
 actor:
   log_each_n_secs: 0
   llm_max_rollouts: 64

--- a/conf/chartqa.yaml
+++ b/conf/chartqa.yaml
@@ -47,6 +47,7 @@ model_path: Qwen/Qwen2.5-VL-3B-Instruct
 
 # Override vLLM config for multimodal support
 vllm_config:
+  use_v1: true
   vllm_kwargs:
     max-num-seqs: 64
     max-num-batched-tokens: 32768

--- a/conf/finetune/actor_critic.yaml
+++ b/conf/finetune/actor_critic.yaml
@@ -4,5 +4,4 @@ defaults:
 
 model_class: causal-language-modeling-with-value-head
 rl:
-  algo: actor_critic
   value_loss_coef: 0.1

--- a/conf/finetune/actor_critic.yaml
+++ b/conf/finetune/actor_critic.yaml
@@ -1,0 +1,8 @@
+defaults:
+  - base
+  - _self_
+
+model_class: causal-language-modeling-with-value-head
+rl:
+  algo: actor_critic
+  value_loss_coef: 0.1

--- a/conf/finetune/base.yaml
+++ b/conf/finetune/base.yaml
@@ -9,6 +9,17 @@ optim: adamw_torch
 load_as_bf16: True
 use_flash_attention: true
 auto_device_map: False
+#LoRA adapter tuning config
+lora:
+  enabled: False
+  task_type: CAUSAL_LM # supported: CAUSAL_LM, SEQ_2_SEQ_LM
+  base_model_8bit: False # format used for storing base mode weights during forward
+  base_model_4bit: False
+  r: 16 # Lora attention dimension.
+  alpha: 16 # the alpha parameter for Lora scaling.
+  dropout: 0.05 # the dropout probability for Lora layers.
+  bias: "none" # Bias type for Lora. Can be 'none', 'all' or 'lora_only'
+  target_modules: [] # the names of the modules to apply Lora to.
 # Overwrite existing model checkpoints. If False, resume training from existing checkpoint if exists
 force_restart: False
 # Rewind dataloder to the last used position if training resumed from existing checkpoint

--- a/conf/finetune/base.yaml
+++ b/conf/finetune/base.yaml
@@ -1,86 +1,34 @@
-data: null
-# Model class. Must be one of the following: causal-language-modeling, seq2seq-language-modeling, vision2seq-language-modeling
-model_class: causal-language-modeling
-# Model name or path of model to be trained.
-config_name: ???
-# Optimizer type, supported: adamw_torch, adafactor, cpuadam, lion
-optim: adamw_torch
-# use half precision training, full bf16 without mixed precision copies at all
-load_as_bf16: True
 use_flash_attention: true
-auto_device_map: False
-#LoRA adapter tuning config
-lora:
-  enabled: False
-  task_type: CAUSAL_LM # supported: CAUSAL_LM, SEQ_2_SEQ_LM
-  base_model_8bit: False # format used for storing base mode weights during forward
-  base_model_4bit: False
-  r: 16 # Lora attention dimension.
-  alpha: 16 # the alpha parameter for Lora scaling.
-  dropout: 0.05 # the dropout probability for Lora layers.
-  bias: "none" # Bias type for Lora. Can be 'none', 'all' or 'lora_only'
-  target_modules: [] # the names of the modules to apply Lora to.
-# Overwrite existing model checkpoints. If False, resume training from existing checkpoint if exists
-force_restart: False
-# Rewind dataloder to the last used position if training resumed from existing checkpoint
-resume_dataloader: False
-# Batch size for training.
-train_batch_size: 4
-# Batch size for evaluation.
-valid_batch_size: 4
-# Value of weight decay.
-weight_decay: 0.01
-# Learning rate for training.
-learning_rate: 0.0000025
-# How much to clip the gradient (no clipping if null)
-gradient_clipping_threshold: 1.0
-# Learning rate scheduler type (indexed by completed_steps).
-lr_scheduler_type: cosine # could be cosine, constant_with_warmup
-# Number of warmup (completed) steps in the learning rate schedule.
-num_warmup_steps: 50
-# Number of gradient accumulation steps.
-gradient_accumulation_passes: 256
-# Use gradient checkpointing to reduce memory footprint.
-gradient_checkpointing: True
-# Number of training steps passed to LR scheduler,
-# also the maximum number of steps if interrupt_train_steps is -1
-max_train_steps: 100000
-# Set interrupt_train_steps to the number of steps after which to interrupt training.
-# Using interrupt_train_steps is useful for stopping training before max_train_steps
-# is reached without affecting the LR scheduler.
-# This is useful for testing purposes.
-# Note that interrupt_train_steps is ignored if equal to -1
-interrupt_train_steps: -1
-# Maximum number of evaluation (completed) steps. If -1 the full dataset is evaluated.
-max_eval_steps: -1
-# Sequence lengths used for training.
-seq_length: 4096
-# Training seed.
-seed: 1
-# Interval to save checkpoints.
-save_checkpoint_steps: ???
-# Whether to keep intermediate checkpoints
-keep_intermediate_checkpoints: True
-# Whether to allow loading external model code
-trust_remote_code: False
-# Whether to empty the cache every training pass. Usually not worth it except for very large models if OOM
-cuda_empty_cache: True
-sft_config_name: null
-n_examples: 0 # 0 means do not limit number of samples
-log_each_n_steps: 10
-also_save_steps: []
-use_safetensors: True
-save_final_training_state: True
-objective: rl
-eval_callback:
-  _target_: tapeagents.finetune.eval.dummy_eval_callback
-  config_name: ""
+attn_implementation: flash_attention_2
+config_name: ${..model_path}
+output_dir: ${..output_dir}/finetune
+seq_length: 12000
+seq_packing: true
 rl:
-  kl_coef: 0.0
-  final_kl_coef: ${..rl.kl_coef}
-  reward_minus_kl_coef: 0.0
-  use_advantages: true
   algo: reinforce
-  temperature: 1.0
+  divide_advantage_by_std: false
+  kl_coef: 0.0
   entropy_bonus: 0.0
-  overlong_filtering: false
+  reward_minus_kl_coef: 0.0
+  epsilon: 4
+  use_advantages: true
+  relu_log_p_weights: false
+  clamp_log_ratio_ref_new_value: 5
+  temperature: ${...llm.parameters.temperature}
+  aggregate_loss: sum
+train_batch_size: 1
+gradient_accumulation_passes: 1024
+gradient_checkpointing: true
+gradient_clipping_threshold: 0.3
+# see https://medium.com/pytorch/how-activation-checkpointing-enables-scaling-up-training-deep-learning-models-7a93ae01ff2d
+# for the motivation to this false by default
+reentrant_checkpointing: false
+learning_rate: 1e-6
+save_checkpoint_steps: 100
+log_each_n_steps: 1
+input: training_data
+send_weight_updates: true
+queue_size: 32
+max_lag: ${..max_lag}
+weight_update_interval: 1
+pop_old_data: ${..pop_old_data}

--- a/conf/finetune/base.yaml
+++ b/conf/finetune/base.yaml
@@ -84,3 +84,5 @@ rl:
   temperature: 1.0
   entropy_bonus: 0.0
   overlong_filtering: false
+  # Coefficient for value loss (when use_value_head is true)
+  value_loss_coef: 0.

--- a/conf/finetune/base.yaml
+++ b/conf/finetune/base.yaml
@@ -91,7 +91,7 @@ rl:
   algo: reinforce
   divide_advantage_by_std: false
   kl_coef: 0.0
-  final_kl_coef: 0.0
+  final_kl_coef: ${..rl.kl_coef} 
   entropy_bonus: 0.0
   reward_minus_kl_coef: 0.0
   epsilon: 4

--- a/conf/finetune/base.yaml
+++ b/conf/finetune/base.yaml
@@ -1,13 +1,97 @@
+data: null
+# Model class. Must be one of the following: causal-language-modeling, seq2seq-language-modeling, vision2seq-language-modeling
+model_class: causal-language-modeling
+# Model name or path of model to be trained.
+config_name: ${..model_path}
+# Optimizer type, supported: adamw_torch, adafactor, cpuadam, lion
+optim: adamw_torch
+# use half precision training, full bf16 without mixed precision copies at all
+load_as_bf16: True
 use_flash_attention: true
 attn_implementation: flash_attention_2
-config_name: ${..model_path}
-output_dir: ${..output_dir}/finetune
+auto_device_map: False
+#LoRA adapter tuning config
+lora:
+  enabled: False
+  task_type: CAUSAL_LM # supported: CAUSAL_LM, SEQ_2_SEQ_LM
+  base_model_8bit: False # format used for storing base mode weights during forward
+  base_model_4bit: False
+  r: 16 # Lora attention dimension.
+  alpha: 16 # the alpha parameter for Lora scaling.
+  dropout: 0.05 # the dropout probability for Lora layers.
+  bias: "none" # Bias type for Lora. Can be 'none', 'all' or 'lora_only'
+  target_modules: [] # the names of the modules to apply Lora to.
+# Overwrite existing model checkpoints. If False, resume training from existing checkpoint if exists
+force_restart: ${..force_restart}
+# Rewind dataloder to the last used position if training resumed from existing checkpoint
+resume_dataloader: False
+# Batch size for training.
+train_batch_size: 1
+# Batch size for evaluation.
+valid_batch_size: 4
+# Value of weight decay.
+weight_decay: 0.01
+# Learning rate for training.
+learning_rate: 1e-6
+# How much to clip the gradient (no clipping if null)
+gradient_clipping_threshold: 0.3
+# Learning rate scheduler type (indexed by completed_steps).
+lr_scheduler_type: cosine # could be cosine, constant_with_warmup
+# Number of warmup (completed) steps in the learning rate schedule.
+num_warmup_steps: 50
+# Number of gradient accumulation steps.
+gradient_accumulation_passes: 1024
+# Use gradient checkpointing to reduce memory footprint.
+gradient_checkpointing: true
+# see https://medium.com/pytorch/how-activation-checkpointing-enables-scaling-up-training-deep-learning-models-7a93ae01ff2d
+# for the motivation to this false by default
+reentrant_checkpointing: false
+# Number of training steps passed to LR scheduler,
+# also the maximum number of steps if interrupt_train_steps is -1
+max_train_steps: 100000
+# Set interrupt_train_steps to the number of steps after which to interrupt training.
+# Using interrupt_train_steps is useful for stopping training before max_train_steps
+# is reached without affecting the LR scheduler.
+# This is useful for testing purposes.
+# Note that interrupt_train_steps is ignored if equal to -1
+interrupt_train_steps: -1
+# Maximum number of evaluation (completed) steps. If -1 the full dataset is evaluated.
+max_eval_steps: -1
+# Sequence lengths used for training.
 seq_length: 12000
 seq_packing: true
+output_dir: ${..output_dir}/finetune
+# Training seed.
+seed: 42
+# Interval to save checkpoints.
+save_checkpoint_steps: 100
+# Whether to keep intermediate checkpoints
+keep_intermediate_checkpoints: True
+# Whether to allow loading external model code
+trust_remote_code: false
+# Whether to empty the cache every training pass. Usually not worth it except for very large models if OOM
+cuda_empty_cache: True
+sft_config_name: null
+n_examples: 0 # 0 means do not limit number of samples
+log_each_n_steps: 1
+also_save_steps: []
+use_safetensors: true
+save_final_training_state: True
+objective: rl
+input: training_data
+send_weight_updates: true
+queue_size: 32
+max_lag: ${..max_lag}
+weight_update_interval: 1
+pop_old_data: ${..pop_old_data}
+eval_callback:
+  _target_: tapeagents.finetune.eval.dummy_eval_callback
+  config_name: ""
 rl:
   algo: reinforce
   divide_advantage_by_std: false
   kl_coef: 0.0
+  final_kl_coef: 0.0
   entropy_bonus: 0.0
   reward_minus_kl_coef: 0.0
   epsilon: 4
@@ -16,19 +100,4 @@ rl:
   clamp_log_ratio_ref_new_value: 5
   temperature: ${...llm.parameters.temperature}
   aggregate_loss: sum
-train_batch_size: 1
-gradient_accumulation_passes: 1024
-gradient_checkpointing: true
-gradient_clipping_threshold: 0.3
-# see https://medium.com/pytorch/how-activation-checkpointing-enables-scaling-up-training-deep-learning-models-7a93ae01ff2d
-# for the motivation to this false by default
-reentrant_checkpointing: false
-learning_rate: 1e-6
-save_checkpoint_steps: 100
-log_each_n_steps: 1
-input: training_data
-send_weight_updates: true
-queue_size: 32
-max_lag: ${..max_lag}
-weight_update_interval: 1
-pop_old_data: ${..pop_old_data}
+  overlong_filtering: false

--- a/conf/finetune/base.yaml
+++ b/conf/finetune/base.yaml
@@ -9,17 +9,6 @@ optim: adamw_torch
 load_as_bf16: True
 use_flash_attention: true
 auto_device_map: False
-#LoRA adapter tuning config
-lora:
-  enabled: False
-  task_type: CAUSAL_LM # supported: CAUSAL_LM, SEQ_2_SEQ_LM
-  base_model_8bit: False # format used for storing base mode weights during forward
-  base_model_4bit: False
-  r: 16 # Lora attention dimension.
-  alpha: 16 # the alpha parameter for Lora scaling.
-  dropout: 0.05 # the dropout probability for Lora layers.
-  bias: "none" # Bias type for Lora. Can be 'none', 'all' or 'lora_only'
-  target_modules: [] # the names of the modules to apply Lora to.
 # Overwrite existing model checkpoints. If False, resume training from existing checkpoint if exists
 force_restart: False
 # Rewind dataloder to the last used position if training resumed from existing checkpoint
@@ -84,5 +73,3 @@ rl:
   temperature: 1.0
   entropy_bonus: 0.0
   overlong_filtering: false
-  # Coefficient for value loss (when use_value_head is true)
-  value_loss_coef: 0.

--- a/conf/finetune/grpo.yaml
+++ b/conf/finetune/grpo.yaml
@@ -1,0 +1,6 @@
+defaults:
+  - base
+  - _self_
+
+rl:
+  algo: ppo

--- a/conf/finetune/ppo.yaml
+++ b/conf/finetune/ppo.yaml
@@ -1,0 +1,8 @@
+defaults:
+  - base
+  - _self_
+
+model_class: causal-language-modeling-with-value-head
+rl:
+  value_loss_coef: 0.1
+  algo: ppo

--- a/conf/math.yaml
+++ b/conf/math.yaml
@@ -1,5 +1,7 @@
 defaults:
     - base
+    - _self_
+
 actor:
   rollout_policy: pipelinerl.domains.math.generate_math_rollout
   system_prompt: Please reason step by step, and put your final answer within \boxed{}.

--- a/pipelinerl/actor.py
+++ b/pipelinerl/actor.py
@@ -616,7 +616,7 @@ def run_actor_loop(cfg: DictConfig):
     wait_for_environments(cfg)
     trainer_state = TrainerState(exp_path)
     if cfg.debug.mode:
-        trainer_state.propagated_weight_version = 0
+        trainer_state.debug_mode_init()
     else:
         trainer_state.start_listening()
         trainer_state.wait_for_model_version()

--- a/pipelinerl/finetune/data.py
+++ b/pipelinerl/finetune/data.py
@@ -197,10 +197,13 @@ def collate(
             logger.debug(f"Skipping key '{k}' - sequences contain str/dict items")
             continue
         else:
+            #TODO: finished key, n_predicted are weirdly padded
             # Handle sequence data: pad as usual
             padded_sequences = []
             pad_value = label_mask_value if k == "labels" else (0.0 if k in RL_DATA_COLUMNS else 0)
             for seq in seq_list:
+                if seq is None:
+                    continue  # Skip None sequences
                 if not isinstance(seq, list):
                     seq = [seq]
                 padding = [pad_value] * (seq_length - len(seq))

--- a/pipelinerl/finetune/data.py
+++ b/pipelinerl/finetune/data.py
@@ -183,6 +183,11 @@ def collate(
     
     for k, seq_list in example_dict.items():
         if any(isinstance(seq, (str, dict)) for seq in seq_list):
+            logger.debug(f"Skipping key '{k}' - contains str/dict sequences")
+            continue
+        # Check if any sequence contains strings or dicts
+        if any(isinstance(item, (str, dict)) for seq in seq_list if isinstance(seq, list) for item in seq):
+            logger.debug(f"Skipping key '{k}' - sequences contain str/dict items")
             continue
         else:
             # Handle sequence data: pad as usual

--- a/pipelinerl/finetune/rl/__init__.py
+++ b/pipelinerl/finetune/rl/__init__.py
@@ -190,9 +190,6 @@ def rl_step(
         model_inputs["pixel_values"] = batch.pixel_values
     if hasattr(batch, 'image_grid_thw') and batch.image_grid_thw is not None:
         model_inputs["image_grid_thw"] = batch.image_grid_thw.reshape((1, 3))
-
-    # Check if model has value head
-    has_value_head = hasattr(model, 'value_head') or (hasattr(model, 'module') and hasattr(model.module, 'value_head'))
     
     outputs = model(**model_inputs)
 
@@ -211,7 +208,6 @@ def rl_step(
 
     # get shifted values and compute ratios
     rewards = batch.rewards[:, 1:]
-    advantages = batch.advantages[:, 1:]
     ref_logprobs = batch.ref_logprobs[:, 1:]
     old_logprobs = batch.old_logprobs[:, 1:]
     group_tokens = batch.group_tokens[:, 1:]
@@ -243,7 +239,7 @@ def rl_step(
         # where MC_return is the Monte Carlo return (rewards) and V(s) is the value prediction
         advantages = rewards - value_predictions
     else:
-        advantages = batch.pop("advantages")[:, 1:]
+        advantages = batch.advantages[:, 1:]
 
     log_p_weights = advantages.detach() if config.use_advantages else rewards
     if config.relu_log_p_weights:

--- a/pipelinerl/finetune/rl/__init__.py
+++ b/pipelinerl/finetune/rl/__init__.py
@@ -94,12 +94,8 @@ class RLConfig(BaseModel):
         description="Filter out groups where all advantages are zero during preprocessing",
     )
     value_loss_coef: float = Field(
-        default=0.1,
+        default=0.0,
         description="Coefficient for the value loss in the final loss",
-    )
-    clip_eps: float = Field(
-        default=0.2,
-        description="Value function clipping parameter",
     )
 
 
@@ -156,6 +152,8 @@ def rl_step(
     masks = batch.labels != -100
     masks_shifted = masks[:, 1:]
 
+    has_value_head = hasattr(model, 'value_head')
+
     # if we have position_ids, we are packing
     if batch.is_packed:
         position_ids = batch.position_ids[0]
@@ -206,11 +204,6 @@ def rl_step(
     entropy = -(probs * logprobs).sum(dim=-1)
     del logits, probs
     
-    # Get value predictions if available
-    value_predictions = None
-    if has_value_head and hasattr(outputs, 'value'):
-        value_predictions = outputs.value[:, :-1]  # Shift to align with other sequences
-
     # get log probs for actual tokens
     new_logprobs = torch.gather(logprobs, dim=2, index=batch.input_ids[:, 1:].unsqueeze(2)).squeeze(2)
     assert torch.isfinite(new_logprobs).all(), f"new_logprobs is not finite: {new_logprobs}"
@@ -242,12 +235,15 @@ def rl_step(
     ratio_new_old = torch.exp(log_ratio_new_old)
     log_ratio_ref_new = ref_logprobs - new_logprobs
     assert torch.isfinite(log_ratio_ref_new).all(), f"log_ratio_ref_new is not finite: {log_ratio_ref_new}"
-    # compute weights and KL divergence
-    # Use value-estimated advantages if available and model has value head
-    if value_predictions is not None:
+
+    if has_value_head:
+        # Get value predictions if available
+        value_predictions = outputs.value[:, :-1] # no target for the last token 
         # Compute value-based advantages: A(s,a) = MC_return - V(s)
         # where MC_return is the Monte Carlo return (rewards) and V(s) is the value prediction
         advantages = rewards - value_predictions
+    else:
+        advantages = batch.pop("advantages")[:, 1:]
 
     log_p_weights = advantages.detach() if config.use_advantages else rewards
     if config.relu_log_p_weights:
@@ -293,9 +289,8 @@ def rl_step(
 
     policy_loss_total = -sum_sum(loss, masks_shifted, segments)
     
-    # Compute value loss if model has value head
-    value_loss = torch.tensor(0.0, device=policy_loss_total.device, dtype=policy_loss_total.dtype)
-    if has_value_head and hasattr(outputs, 'value') and outputs.value is not None:
+    final_loss = policy_loss_total
+    if has_value_head:
         # Get the value predictions
         values = outputs.value
         # Use the already extracted and shifted rewards as value labels
@@ -309,9 +304,7 @@ def rl_step(
         value_loss = sum_sum(value_loss, masks_shifted, segments) 
         
         # Combine policy loss and value loss
-        final_loss = policy_loss_total + config.value_loss_coef * value_loss
-    else:
-        final_loss = policy_loss_total
+        final_loss = final_loss + config.value_loss_coef * value_loss
 
     # ensure loss is valid
     assert torch.isfinite(final_loss), f"Non-finite loss detected: {final_loss}"
@@ -321,7 +314,6 @@ def rl_step(
         "loss": final_loss.item(),
         "max_loss": final_loss.item(),
         "min_loss": final_loss.item(),
-        "value_loss": value_loss.item() if torch.is_tensor(value_loss) else value_loss,
         "reward": mean_sum(rewards, masks_shifted, segments).item(),
         "max_reward": rewards[masks_shifted].max().item(),
         "min_reward": rewards[masks_shifted].min().item(),
@@ -359,12 +351,16 @@ def rl_step(
         "entropy_bonus_coef": num_sequences * entropy_bonus_coef,
         "num_output_tokens_sum": masks_shifted.sum().item(),
     }
+
+    if has_value_head:
+        value_stats = {
+            "value_mean": mean_sum(value_predictions, masks_shifted, segments).item(),
+            "value_max": value_predictions[masks_shifted].max().item(),
+            "value_min": value_predictions[masks_shifted].min().item(),
+            "value_loss": value_loss.item(),
+        }
+        stats.update(value_stats)
     
-    # Add value prediction stats if available
-    if value_predictions is not None:
-        stats["value_mean"] = mean_sum(value_predictions, masks_shifted, segments).item()
-        stats["value_max"] = value_predictions[masks_shifted].max().item() if masks_shifted.any() else 0.0
-        stats["value_min"] = value_predictions[masks_shifted].min().item() if masks_shifted.any() else 0.0
 
     return final_loss, stats
 

--- a/pipelinerl/finetune/rl/__init__.py
+++ b/pipelinerl/finetune/rl/__init__.py
@@ -189,7 +189,7 @@ def rl_step(
     if hasattr(batch, 'pixel_values') and batch.pixel_values is not None:
         model_inputs["pixel_values"] = batch.pixel_values
     if hasattr(batch, 'image_grid_thw') and batch.image_grid_thw is not None:
-        model_inputs["image_grid_thw"] = batch.image_grid_thw.reshape((1, 3))
+        model_inputs["image_grid_thw"] = batch.image_grid_thw #torch.tensor(.reshape((1, 3))
     
     outputs = model(**model_inputs)
 

--- a/pipelinerl/finetune/rl/__init__.py
+++ b/pipelinerl/finetune/rl/__init__.py
@@ -261,7 +261,7 @@ def rl_step(
 
     # compute algorithm-specific losses
     match config.algo:
-        case "grpo":
+        case "ppo":
             surr1 = ratio_new_old * log_p_weights
             clamped_ratio = torch.clamp(ratio_new_old, 1 - config.epsilon, 1 + config.epsilon)
             clamp_log_ratio_new_old_indicators = clamped_ratio != ratio_new_old

--- a/pipelinerl/finetune/rl/__init__.py
+++ b/pipelinerl/finetune/rl/__init__.py
@@ -158,7 +158,7 @@ def rl_step(
 
     # if we have position_ids, we are packing
     if batch.is_packed:
-        position_ids = batch.position_ids
+        position_ids = batch.position_ids[0]
         # sequence boundary computation
         sequence_starts = torch.where(position_ids == 0)[0]
         seq_boundaries = torch.cat(

--- a/pipelinerl/finetune/types.py
+++ b/pipelinerl/finetune/types.py
@@ -71,18 +71,22 @@ class PipelineBatchEncoding(BaseModel):
     
     @field_validator('input_ids', 'attention_mask', 'labels', 'position_ids', mode='before')
     @classmethod
-    def convert_to_long_tensor(cls, v: List[int] | None) -> torch.LongTensor | None:
+    def convert_to_long_tensor(cls, v: List[int] | torch.Tensor | None) -> torch.LongTensor | None:
         """Convert lists to long tensors."""
         if v is None:
             return None
+        if isinstance(v, torch.Tensor):
+            return v.long()
         return torch.tensor(v, dtype=torch.long)
     
     @field_validator('rewards', 'advantages', 'ref_logprobs', 'old_logprobs', 'group_tokens', 'overflow', 'pixel_values', mode='before')
     @classmethod
-    def convert_to_float_tensor(cls, v: List[float] | None) -> torch.FloatTensor | None:
+    def convert_to_float_tensor(cls, v: List[float] | torch.Tensor | None) -> torch.FloatTensor | None:
         """Convert lists to float tensors."""
         if v is None:
             return None
+        if isinstance(v, torch.Tensor):
+            return v.float()
         return torch.tensor(v, dtype=torch.float)
     
     def to_device(self, device: Union[str, torch.device]) -> 'PipelineBatchEncoding':

--- a/pipelinerl/finetune/types.py
+++ b/pipelinerl/finetune/types.py
@@ -67,9 +67,9 @@ class PipelineBatchEncoding(BaseModel):
     
     # Visual feature fields (optional, for multimodal models)
     pixel_values: torch.FloatTensor | None = None
-    image_grid_thw: List[List[int]] | None = None
+    image_grid_thw: torch.LongTensor | None = None
     
-    @field_validator('input_ids', 'attention_mask', 'labels', 'position_ids', mode='before')
+    @field_validator('input_ids', 'attention_mask', 'labels', 'position_ids', 'image_grid_thw', mode='before')
     @classmethod
     def convert_to_long_tensor(cls, v: List[int] | torch.Tensor | None) -> torch.LongTensor | None:
         """Handle initialization of long tensors from different types."""

--- a/pipelinerl/finetune/types.py
+++ b/pipelinerl/finetune/types.py
@@ -72,22 +72,26 @@ class PipelineBatchEncoding(BaseModel):
     @field_validator('input_ids', 'attention_mask', 'labels', 'position_ids', mode='before')
     @classmethod
     def convert_to_long_tensor(cls, v: List[int] | torch.Tensor | None) -> torch.LongTensor | None:
-        """Convert lists to long tensors."""
+        """Handle initialization of long tensors from different types."""
         if v is None:
             return None
         if isinstance(v, torch.Tensor):
             return v.long()
-        return torch.tensor(v, dtype=torch.long)
+        if isinstance(v, list) or isinstance(v, np.ndarray):
+            return torch.tensor(v, dtype=torch.long)
+        raise ValueError(f"Unsupported type for long tensor: {type(v)}")
     
     @field_validator('rewards', 'advantages', 'ref_logprobs', 'old_logprobs', 'group_tokens', 'overflow', 'pixel_values', mode='before')
     @classmethod
     def convert_to_float_tensor(cls, v: List[float] | torch.Tensor | None) -> torch.FloatTensor | None:
-        """Convert lists to float tensors."""
+        """Handle initialization of float tensors from different types."""
         if v is None:
             return None
         if isinstance(v, torch.Tensor):
             return v.float()
-        return torch.tensor(v, dtype=torch.float)
+        if isinstance(v, list) or isinstance(v, np.ndarray):
+            return torch.tensor(v, dtype=torch.float)
+        raise ValueError(f"Unsupported type for float tensor: {type(v)}")
     
     def to_device(self, device: Union[str, torch.device]) -> 'PipelineBatchEncoding':
         """Move all tensors to the specified device and return updated instance."""

--- a/pipelinerl/finetune/utils.py
+++ b/pipelinerl/finetune/utils.py
@@ -46,6 +46,7 @@ def create_sentinel_batch(device, tokenizer=None, model_version=0) -> BatchEncod
         "old_logprobs": torch.tensor(zeros, dtype=torch.float).reshape(1, -1),
         "group_tokens": torch.tensor(ones, dtype=torch.float).reshape(1, -1),
         "overflow": torch.tensor(zeros, dtype=torch.float).reshape(1, -1),
+        "sentinel": torch.tensor([1], dtype=torch.float).reshape(1, -1),
     }
 
     sentinel_batch = {

--- a/pipelinerl/finetune/value_model.py
+++ b/pipelinerl/finetune/value_model.py
@@ -1,0 +1,246 @@
+import os
+import torch
+import torch.nn as nn
+from dataclasses import dataclass
+from transformers import PreTrainedModel
+from transformers.modeling_outputs import ModelOutput
+from typing import Optional, Tuple, Union
+from transformers import AutoModelForCausalLM
+from .context import get_accelerator, logger
+
+
+@dataclass
+class CausalLMOutputWithValue(ModelOutput):
+    """
+    Output type for causal language models with an additional value head.
+
+    Args:
+        loss (`torch.FloatTensor` of shape `(1,)`, *optional*):
+            Language modeling loss.
+        logits (`torch.FloatTensor` of shape `(batch_size, sequence_length, vocab_size)`):
+            Prediction scores of the language modeling head.
+        value (`torch.FloatTensor` of shape `(batch_size, sequence_length)`):
+            Value predictions from the value head.
+        value_loss (`torch.FloatTensor` of shape `(1,)`, *optional*):
+            Value prediction loss.
+        past_key_values (`tuple(tuple(torch.FloatTensor))`, *optional*):
+            Contains cached key/value states.
+        hidden_states (`tuple(torch.FloatTensor)`, *optional*):
+            Hidden states of the model at the output of each layer.
+        attentions (`tuple(torch.FloatTensor)`, *optional*):
+            Attention weights after the attention softmax.
+    """
+
+    loss: Optional[torch.FloatTensor] = None
+    logits: torch.FloatTensor = None
+    value: torch.FloatTensor = None
+    value_loss: Optional[torch.FloatTensor] = None
+    past_key_values: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
+    hidden_states: Optional[Tuple[torch.FloatTensor]] = None
+    attentions: Optional[Tuple[torch.FloatTensor]] = None
+
+
+class ValueHead(nn.Module):
+    """Value head for predicting rewards/values."""
+
+    def __init__(self, hidden_size: int):
+        super().__init__()
+        self.output = nn.Linear(hidden_size, 1)
+        nn.init.normal_(self.output.weight, std=1e-3)
+        nn.init.zeros_(self.output.bias)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        values = self.output(hidden_states).squeeze(-1)  # (batch_size, sequence_length)
+        return values
+
+
+class AutoModelForCausalLMWithValueHead(nn.Module):
+    """
+    A wrapper around a causal language model that adds a value head for PPO training.
+    """
+
+    def __init__(self, pretrained_model):
+        super().__init__()
+        self.pretrained_model = pretrained_model
+        self.config = pretrained_model.config
+        hidden_size = self.config.hidden_size
+
+        # Initialize value head
+        self.value_head = ValueHead(hidden_size)
+
+        # Copy relevant attributes from the pretrained model
+        self.main_input_name = pretrained_model.main_input_name
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        value_labels: Optional[torch.FloatTensor] = None,
+    ) -> Union[Tuple, CausalLMOutputWithValue]:
+        """
+        Forward pass that computes both language modeling outputs and value predictions.
+
+        Args:
+            value_labels (`torch.FloatTensor` of shape `(batch_size, sequence_length)`, *optional*):
+                Labels for computing the value loss. These are the rewards to predict.
+        """
+
+        # Get outputs from the base model
+        outputs = self.pretrained_model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            labels=labels,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=True,
+            return_dict=True,
+        )
+
+        # Get the last hidden states
+        hidden_states = outputs.hidden_states[-1]
+
+        # Compute values
+        values = self.value_head(hidden_states)
+
+        return CausalLMOutputWithValue(
+            loss=outputs.loss,
+            logits=outputs.logits,
+            value=values,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
+
+    def gradient_checkpointing_enable(self, gradient_checkpointing_kwargs=None):
+        """Enable gradient checkpointing for the model."""
+        self.pretrained_model.gradient_checkpointing_enable(
+            gradient_checkpointing_kwargs
+        )
+    
+    def save_checkpoint(self, save_dir, tag=None, client_state={}):
+        """Save checkpoint compatible with DeepSpeed.
+        
+        This method is called by DeepSpeed during checkpointing.
+        """
+        import os
+        logger.info(f"Saving DeepSpeed checkpoint to {save_dir}")
+        
+        # For DeepSpeed compatibility, we need to return success
+        # The actual model saving is handled by DeepSpeed's internal mechanisms
+        # We just need to save our custom value head separately
+        if hasattr(self, '_deepspeed_engine'):
+            # If we're wrapped by DeepSpeed, delegate to it
+            return self._deepspeed_engine.save_checkpoint(save_dir, tag=tag, client_state=client_state)
+        
+        # Otherwise, save manually (this shouldn't happen in DeepSpeed mode)
+        return True
+    
+    def save_pretrained(
+        self,
+        save_directory: Union[str, os.PathLike],
+        is_main_process: bool = True,
+        state_dict: Optional[dict] = None,
+        save_function: callable = torch.save,
+        safe_serialization: bool = False,
+        **kwargs,
+    ):
+        """Save model with value head.
+        
+        This saves both the pretrained model and the value head weights separately.
+        """
+        import os
+        
+        if state_dict is None:
+            state_dict = self.state_dict()
+        
+        # Extract pretrained model and value head state dicts
+        pretrained_model_state_dict = {}
+        value_head_state_dict = {}
+        
+        for key, value in state_dict.items():
+            if key.startswith("value_head."):
+                # Remove the "value_head." prefix
+                new_key = key[len("value_head."):]
+                value_head_state_dict[new_key] = value
+            elif key.startswith("pretrained_model."):
+                # Remove the "pretrained_model." prefix
+                new_key = key[len("pretrained_model."):]
+                pretrained_model_state_dict[new_key] = value
+            else:
+                # Handle keys that don't have expected prefixes
+                logger.warning(f"Unexpected key in state dict: {key}")
+                # Try to determine where it belongs based on the model structure
+                if hasattr(self.value_head, key.split('.')[0]):
+                    value_head_state_dict[key] = value
+                else:
+                    pretrained_model_state_dict[key] = value
+        
+        # Save the pretrained model
+        self.pretrained_model.save_pretrained(
+            save_directory,
+            is_main_process=is_main_process,
+            state_dict=pretrained_model_state_dict,
+            save_function=save_function,
+            safe_serialization=safe_serialization,
+            **kwargs,
+        )
+        
+        # Save value head separately
+        if is_main_process:
+            value_head_path = os.path.join(save_directory, "value_head.pt")
+            save_function(value_head_state_dict, value_head_path)
+            logger.info(f"Saved value head to {value_head_path}")
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
+        """Load a model with value head from pretrained weights."""
+
+        logger.info(f"Loading pretrained model from {pretrained_model_name_or_path}...")
+
+        # Load the base model
+        pretrained_model = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name_or_path, *model_args, **kwargs
+        )
+
+        # Create the model with value head
+        model = cls(pretrained_model)
+
+        # Try to load value head weights if they exist
+        value_head_path = os.path.join(pretrained_model_name_or_path, "value_head.pt")
+        if os.path.exists(value_head_path):
+            value_head_state_dict = torch.load(value_head_path, map_location="cpu")
+            model.value_head.load_state_dict(value_head_state_dict)
+
+        return model
+
+    def resize_token_embeddings(self, *args, **kwargs):
+        """Resize token embeddings."""
+        return self.pretrained_model.resize_token_embeddings(*args, **kwargs)
+
+    @property
+    def device(self):
+        """Get the device of the model."""
+        return self.pretrained_model.device
+
+    @property
+    def dtype(self):
+        """Get the dtype of the model."""
+        return self.pretrained_model.dtype
+
+    def __getattr__(self, name):
+        """Forward attribute access to the pretrained model."""
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            return getattr(self.pretrained_model, name)

--- a/pipelinerl/finetune_loop.py
+++ b/pipelinerl/finetune_loop.py
@@ -571,9 +571,11 @@ def rl_finetuning_worker(
         # check if current worker has process enough data to do a grad step
         if local_samples[0] == target_samples_per_worker:
             logger.debug("creating sentinel batch")
-            versioned_batch = create_sentinel_batch(
+            sentinel_batch = create_sentinel_batch(
                 get_accelerator().device, tokenizer, model_version=last_model_version
             )
+            # Wrap sentinel batch in VersionedTensors to match data_generator format
+            versioned_batch = VersionedTensors(tensors=sentinel_batch, model_version=last_model_version)
             is_sentinel_batch = True
         else:
             versioned_batch = next(data_generator)

--- a/pipelinerl/finetune_loop.py
+++ b/pipelinerl/finetune_loop.py
@@ -106,6 +106,7 @@ def run_data_loader(
 
                     # Convert to PipelineBatchEncoding and move to device
                     pipeline_batch = PipelineBatchEncoding(**batch_encoding)
+                    #TODO: put to deivce when taken out fo the queue
                     pipeline_batch = pipeline_batch.to_device(get_accelerator().device)
                     batch_queue.put(pipeline_batch)
                     logger.debug(f"Loaded batch, queue size is now {batch_queue.qsize()}")

--- a/pipelinerl/finetune_loop.py
+++ b/pipelinerl/finetune_loop.py
@@ -206,8 +206,14 @@ class WeightUpdateManager:
         ):
             module = self.accelerated_model.module
             logger.info("Start gathering and sending ZeRO Stage 3 weights")
-            named_parameters = dict(module.named_parameters())
-
+            
+            # Filter out value head parameters and get only the pretrained model parameters
+            named_parameters = {
+                name.replace('pretrained_model.', ''): param 
+                for name, param in module.named_parameters() 
+                if name.startswith('pretrained_model.') and not name.startswith('pretrained_model.value_head.')
+            }
+            
             if get_accelerator().is_main_process:
                 parameters_info = [
                     # assume DeepSpeed Stage 3
@@ -246,7 +252,9 @@ class WeightUpdateManager:
                     del named_parameters["lm_head.weight"]
             else:
                 unwrapped = get_accelerator().unwrap_model(self.accelerated_model)
-                named_parameters = dict(unwrapped.named_parameters())
+                # Filter out value head parameters
+                named_parameters = {name: param for name, param in unwrapped.named_parameters() 
+                                  if not name.startswith('value_head.')}
             if get_accelerator().is_main_process:
                 assert self.update_stream is not None
                 parameters_info = [

--- a/pipelinerl/finetune_loop.py
+++ b/pipelinerl/finetune_loop.py
@@ -769,7 +769,6 @@ def rl_finetuning_worker(
             time_waiting_for_data = 0.0
 
             average_rl_metrics = get_avg_rl_stats(gathered_rl_metrics, samples_per_step)
-            print(f"DEBUG: loss = {average_rl_metrics['rl/loss']}")
             ess = (
                 average_rl_metrics["rl/ratio_new_old_sum"] ** 2
                 / average_rl_metrics["rl/ratio_new_old_squared_sum"]

--- a/pipelinerl/finetune_loop.py
+++ b/pipelinerl/finetune_loop.py
@@ -138,19 +138,13 @@ class WeightUpdateSuccess(BaseModel):
     version: int
     timestamp: float = time.time()
 
-
-class WeightBeingSavedToDisk(BaseModel):
-    kind: Literal["weight_being_saved_to_disk"] = "weight_being_saved_to_disk"
-    version: int
-    timestamp: float = time.time()
-
-    
+ 
 class SamplesProcessed(BaseModel):
     kind: Literal["samples_processed"] = "samples_processed"
     samples_processed: int
     timestamp: float = time.time()
 
-TrainerMessage = WeightUpdateRequest | WeightUpdateSuccess | WeightBeingSavedToDisk | SamplesProcessed
+TrainerMessage = WeightUpdateRequest | WeightUpdateSuccess | SamplesProcessed
 
 
 class WeightUpdateManager:

--- a/pipelinerl/finetune_loop.py
+++ b/pipelinerl/finetune_loop.py
@@ -106,7 +106,6 @@ def run_data_loader(
 
                     # Convert to PipelineBatchEncoding and move to device
                     pipeline_batch = PipelineBatchEncoding(**batch_encoding)
-                    #TODO: put to deivce when taken out fo the queue
                     pipeline_batch = pipeline_batch.to_device(get_accelerator().device)
                     batch_queue.put(pipeline_batch)
                     logger.debug(f"Loaded batch, queue size is now {batch_queue.qsize()}")

--- a/pipelinerl/finetune_loop.py
+++ b/pipelinerl/finetune_loop.py
@@ -571,6 +571,7 @@ def rl_finetuning_worker(
 
         versioned_batch = next(data_generator)
         is_sentinel_batch = bool(versioned_batch.tensors.get("sentinel", False))
+        #TODO: rm debug code
         if local_samples[0] == target_samples_per_worker:
             assert is_sentinel_batch, "We should get a sentinel batch"
             logger.info("next batch should be a sentinel batch")

--- a/pipelinerl/finetune_loop.py
+++ b/pipelinerl/finetune_loop.py
@@ -109,14 +109,18 @@ def run_data_loader(
                         batch_encoding = BatchEncoding(batch_encoding)
                     
                     # Move tensors to device, converting lists to tensors for known tensor fields
-                    tensor_fields = {'input_ids', 'attention_mask', 'labels', 'position_ids', 'rewards', 'advantages', 'ref_logprobs', 'old_logprobs', 'group_tokens', 'overflow'}
+                    long_tensor_fields = {'input_ids', 'attention_mask', 'labels', 'position_ids'}
+                    float_tensor_fields = {'rewards', 'advantages', 'ref_logprobs', 'old_logprobs', 'group_tokens', 'overflow'}
                     batch = {}
                     for k, v in batch_encoding.items():
                         if isinstance(v, torch.Tensor):
                             batch[k] = v.to(get_accelerator().device)
-                        elif k in tensor_fields and isinstance(v, list):
-                            # Convert lists back to tensors for known tensor fields
+                        elif k in long_tensor_fields and isinstance(v, list):
+                            # Convert lists to long tensors for integer fields
                             batch[k] = torch.tensor(v, dtype=torch.long).to(get_accelerator().device)
+                        elif k in float_tensor_fields and isinstance(v, list):
+                            # Convert lists to float tensors for floating point fields
+                            batch[k] = torch.tensor(v, dtype=torch.float).to(get_accelerator().device)
                         else:
                             batch[k] = v
                     

--- a/pipelinerl/finetune_loop.py
+++ b/pipelinerl/finetune_loop.py
@@ -183,7 +183,7 @@ class WeightUpdateManager:
         ):
             module = self.accelerated_model.module
             logger.info("Start gathering and sending ZeRO Stage 3 weights")
-            
+
             # Filter out value head parameters and get only the pretrained model parameters
             named_parameters = (
                 dict(module.pretrained_model.named_parameters())

--- a/pipelinerl/finetune_loop.py
+++ b/pipelinerl/finetune_loop.py
@@ -24,6 +24,7 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.api import MixedPrecision
 from transformers import PreTrainedTokenizerFast, get_scheduler, set_seed
 
+from pipelinerl.finetune.value_model import AutoModelForCausalLMWithValueHead
 import pipelinerl.torch_utils
 from pipelinerl.finetune.types import PipelineBatchEncoding
 from pipelinerl.finetune.checkpoints import (
@@ -184,11 +185,11 @@ class WeightUpdateManager:
             logger.info("Start gathering and sending ZeRO Stage 3 weights")
             
             # Filter out value head parameters and get only the pretrained model parameters
-            named_parameters = {
-                name.replace('pretrained_model.', ''): param 
-                for name, param in module.named_parameters() 
-                if name.startswith('pretrained_model.') and not name.startswith('pretrained_model.value_head.')
-            }
+            named_parameters = (
+                dict(module.pretrained_model.named_parameters())
+                if isinstance(module, AutoModelForCausalLMWithValueHead)
+                else dict(module.named_parameters())
+            )
             
             if get_accelerator().is_main_process:
                 parameters_info = [

--- a/pipelinerl/launch.py
+++ b/pipelinerl/launch.py
@@ -58,11 +58,8 @@ def validate_config(cfg: DictConfig):
     
     # Check for value loss coefficient constraints
     if cfg.finetune.model_class == "causal-language-modeling-with-value-head":
-        if cfg.finetune.rl.value_loss_coef <= 0.0:
+        if not hasattr(cfg.finetune.rl, "value_loss_coef") or cfg.finetune.rl.value_loss_coef <= 0.0:
             raise ValueError("value_loss_coef must be greater than 0 when using causal-language-modeling-with-value-head")
-    else:
-        if cfg.finetune.rl.value_loss_coef != 0.0:
-            raise ValueError("value_loss_coef must be 0 when not using causal-language-modeling-with-value-head")
 
 
 def run_ref_llm(cfg: DictConfig, preprocessor_llm_idx: int, local_idx: int, gpus: list[int], exp_dir: Path):

--- a/pipelinerl/launch.py
+++ b/pipelinerl/launch.py
@@ -296,7 +296,7 @@ def run_finetune(cfg: DictConfig, world_map: WorldMap, gpus: list[int], exp_dir:
         f"+me.weight_update_group_world_size={world_map.weight_update_group_size}",
         f"+me.llm_urls={'+'.join(world_map.get_actor_urls())}",
     ]
-    if cfg.debug.mode in ["finetune", "open_loop"]:
+    if cfg.debug.mode in ["finetune", "open_loop", "finetune+preprocessor"]:
         cmd.append("finetune.send_weight_updates=False")
 
     logger.info(f"Running finetune with command: {' '.join(cmd)}")
@@ -551,6 +551,8 @@ def main(cfg: DictConfig):
             debug_link_streams(cfg, [cfg.finetune.input])
         elif cfg.debug.mode == "preprocessor":
             debug_link_streams(cfg, [cfg.preprocess.input])
+        elif cfg.debug.mode == "finetune+preprocessor":
+            debug_link_streams(cfg, [cfg.preprocess.input])
     else:
         with read_stream(lead_launcher_stream) as stream:
             if (msg := next(stream.read())) != init_msg:
@@ -565,6 +567,8 @@ def main(cfg: DictConfig):
         processes.extend(launch_jobs(cfg, world_map, ["preprocessor", "preprocessor_llm"]))
     elif cfg.debug.mode == "actor+preprocessor":
         processes.extend(launch_jobs(cfg, world_map, ["actor", "environment", "actor_llm", "preprocessor", "preprocessor_llm"]))       
+    elif cfg.debug.mode == "finetune+preprocessor":
+        processes.extend(launch_jobs(cfg, world_map, ["finetune", "preprocessor", "preprocessor_llm"]))
     elif cfg.debug.mode in ["", "open_loop"]:
         processes.extend(launch_jobs(cfg, world_map))
     else:

--- a/pipelinerl/launch.py
+++ b/pipelinerl/launch.py
@@ -55,6 +55,14 @@ def validate_config(cfg: DictConfig):
             raise ValueError("Vision language models cannot use sequence packing (seq_packing must be false)")
         if cfg.finetune.train_batch_size > 1:
             raise ValueError("Vision language models cannot use batch size > 1 (train_batch_size must be 1)")
+    
+    # Check for value loss coefficient constraints
+    if cfg.finetune.model_class == "causal-language-modeling-with-value-head":
+        if cfg.finetune.rl.value_loss_coef <= 0.0:
+            raise ValueError("value_loss_coef must be greater than 0 when using causal-language-modeling-with-value-head")
+    else:
+        if cfg.finetune.rl.value_loss_coef != 0.0:
+            raise ValueError("value_loss_coef must be 0 when not using causal-language-modeling-with-value-head")
 
 
 def run_ref_llm(cfg: DictConfig, preprocessor_llm_idx: int, local_idx: int, gpus: list[int], exp_dir: Path):

--- a/pipelinerl/preprocess.py
+++ b/pipelinerl/preprocess.py
@@ -499,11 +499,6 @@ def run_preprocessing_loop(
                             # If buffer size is not set, no point in logging
                             logger.info(f"Buffer is full with {buffer.qsize()} samples, start writing")
 
-                    # Process entries directly from the queue
-                    # print how many entries in buffer
-
-
-
                     while not buffer.empty():
                         try:
                             if len(processed_entries_queue) == processed_entries_queue.maxlen:

--- a/pipelinerl/preprocess.py
+++ b/pipelinerl/preprocess.py
@@ -605,12 +605,7 @@ def run_preprocessing_loop(
                                                 break
                                     
                                         if current_batch:
-                                            # Create BatchEncoding using collate_packed function
                                             batch_encoding = collate_packed(current_batch, tokenizer=tokenizer)
-                                            # Add model_version to the BatchEncoding for finetune_loop compatibility
-                                            model_versions = [entry["model_version"] for entry in current_batch]
-                                            batch_encoding["model_version"] = model_versions
-                                            # Write the BatchEncoding object to stream
                                             writer.write(batch_encoding)
                                             published_samples += len(current_batch)
                                             samples_per_worker[worker_id] += len(current_batch)
@@ -624,13 +619,7 @@ def run_preprocessing_loop(
                                     batch_entries = []
                                     for _ in range(batch_size):
                                         batch_entries.append(processed_entries_queue.popleft())
-                                    
-                                    # Create BatchEncoding using collate function (supports multiple forward passes)
                                     batch_encoding = collate(batch_entries, tokenizer=tokenizer)
-                                    # Add model_version to the BatchEncoding for finetune_loop compatibility
-                                    model_versions = [entry["model_version"] for entry in batch_entries]
-                                    batch_encoding["model_version"] = model_versions
-                                    # Write the BatchEncoding object to stream
                                     writer.write(batch_encoding)
                                     published_samples += len(batch_entries)
                                     samples_per_worker[worker_id] += len(batch_entries)

--- a/pipelinerl/preprocess.py
+++ b/pipelinerl/preprocess.py
@@ -405,7 +405,7 @@ def run_preprocessing_loop(
     buffer = []
     # Queue for holding processed entries, with size based on batch_size * accumulation_steps
     batch_size = cfg.finetune.train_batch_size
-    accumulation_steps = cfg.finetune.gradient_accumulation_steps
+    accumulation_steps = cfg.finetune.gradient_accumulation_passes
     max_queue_size = batch_size * accumulation_steps
     processed_entries_queue = deque(maxlen=max_queue_size)
     

--- a/pipelinerl/preprocess.py
+++ b/pipelinerl/preprocess.py
@@ -536,7 +536,7 @@ def run_preprocessing_loop(
                         logger.debug(f"[inner loop] trainer {trainer_id} has {samples_per_trainer[trainer_id]} samples, target is {target_samples_per_trainer}")
                         if cfg.finetune.seq_packing:
                             if samples_per_trainer[trainer_id] == target_samples_per_trainer:
-                                logger.info(f"[inner loop] trainer {trainer_id} has all {target_samples_per_trainer} samples, creating sentinel batch")
+                                logger.debug(f"[inner loop] trainer {trainer_id} has all {target_samples_per_trainer} samples, creating sentinel batch")
                                 sentinel_batch = create_sentinel_batch(
                                     device=None,
                                     tokenizer=tokenizer,

--- a/pipelinerl/preprocess.py
+++ b/pipelinerl/preprocess.py
@@ -495,7 +495,7 @@ def run_preprocessing_loop(
                                         logger.warning(f"Popped {processed_entries_queue_popped_data} old entries from processed entries queue")
                                         last_time_notice = processed_entries_queue_popped_data // 100
                             entry = buffer.get_nowait()
-                            processed_entries_queue.append(entry)
+                            processed_entries_queue.append(entry) # drop from the left if full
                         except Empty:
                             break
 

--- a/pipelinerl/preprocess.py
+++ b/pipelinerl/preprocess.py
@@ -575,8 +575,6 @@ def run_preprocessing_loop(
                             for worker_id in range(num_workers):
                                 logger.info(f"Worker {worker_id} has {samples_per_worker[worker_id]} samples, target is {target_samples_per_worker[worker_id]}")
                                 if cfg.finetune.seq_packing:
-                                    # if worker has enough samples, create a sentinel batch
-                                    #TODO: rm debug code
                                     if samples_per_worker[worker_id] == target_samples_per_worker[worker_id]:
                                         logger.info(f"Worker {worker_id} has {samples_per_worker[worker_id]}/{target_samples_per_worker[worker_id]} samples, creating sentinel batch")
                                         sentinel_batch = create_sentinel_batch(

--- a/pipelinerl/preprocess.py
+++ b/pipelinerl/preprocess.py
@@ -563,7 +563,7 @@ def run_preprocessing_loop(
                                     logger.info(f"Packed batch with {len(current_batch)} samples for worker {worker_id}")
                         else:
                             batch_entries = []
-                            for _ in range(batch_size):
+                            for _ in range(cfg.finetune.train_batch_size ):
                                 batch_entries.append(processed_entries_queue.popleft())
                             batch_encoding = collate(batch_entries, tokenizer=tokenizer)
                             writer.write(batch_encoding)

--- a/pipelinerl/preprocess.py
+++ b/pipelinerl/preprocess.py
@@ -466,7 +466,7 @@ def run_preprocessing_loop(
     samples_per_worker_per_step = batch_size * accumulation_steps
     num_workers = world_map.total_finetune_gpus
     max_queue_size = samples_per_worker_per_step * num_workers
-    processed_entries_queue = deque(maxlen=max_queue_size*1000)
+    processed_entries_queue = deque(maxlen=max_queue_size)
     
     # Per-worker sample tracking (similar to finetune_loop.py)
     samples_per_worker = [0] * num_workers  # Track samples written per worker

--- a/pipelinerl/state.py
+++ b/pipelinerl/state.py
@@ -42,10 +42,10 @@ class TrainerState:
         self._thread.start()
     
     def wait_for_processed_samples(self):
-        while self.processed_samples is None:
+        while self.samples_processed is None:
             logger.info("Waiting for the trainer to declare the number of processed samples")
             time.sleep(1)
-        return self.processed_samples
+        return self.samples_processed
 
     def wait_for_model_version(self):
         while self.propagated_weight_version is None:

--- a/pipelinerl/state.py
+++ b/pipelinerl/state.py
@@ -8,7 +8,6 @@ from pydantic import TypeAdapter
 from pipelinerl.finetune_loop import (
     TRAINER_TOPIC,
     TrainerMessage,
-    WeightBeingSavedToDisk,
     WeightUpdateSuccess,
     SamplesProcessed,
 )
@@ -21,8 +20,11 @@ class TrainerState:
     def __init__(self, exp_path: Path):
         self.exp_path = exp_path
         self.propagated_weight_version: int | None = None
-        self.version_weight_last_save: int | None = None
         self.samples_processed: int | None = None
+
+    def debug_mode_init(self):
+        self.propagated_weight_version = 0
+        self.samples_processed = 0
 
     def start_listening(self):
         stream = SingleStreamSpec(exp_path=self.exp_path, topic=TRAINER_TOPIC)
@@ -33,8 +35,6 @@ class TrainerState:
                     message = TypeAdapter(TrainerMessage).validate_python(line)
                     if isinstance(message, WeightUpdateSuccess):
                         self.propagated_weight_version = message.version
-                    if isinstance(message, WeightBeingSavedToDisk):
-                        self.version_weight_last_save = message.version
                     if isinstance(message, SamplesProcessed):
                         self.samples_processed = message.samples_processed
 

--- a/pipelinerl/state.py
+++ b/pipelinerl/state.py
@@ -43,7 +43,7 @@ class TrainerState:
     
     def wait_for_processed_samples(self):
         while self.processed_samples is None:
-            logger.info("Waiting for the trainer to declare the processed samples")
+            logger.info("Waiting for the trainer to declare the number of processed samples")
             time.sleep(1)
         return self.processed_samples
 

--- a/pipelinerl/state.py
+++ b/pipelinerl/state.py
@@ -10,7 +10,7 @@ from pipelinerl.finetune_loop import (
     TrainerMessage,
     WeightBeingSavedToDisk,
     WeightUpdateSuccess,
-    OptimizerStepTrigger,
+    SamplesProcessed,
 )
 from pipelinerl.streams import SingleStreamSpec, read_stream
 
@@ -22,7 +22,7 @@ class TrainerState:
         self.exp_path = exp_path
         self.propagated_weight_version: int | None = None
         self.version_weight_last_save: int | None = None
-        self.processed_samples: int | None = None
+        self.samples_processed: int | None = None
 
     def start_listening(self):
         stream = SingleStreamSpec(exp_path=self.exp_path, topic=TRAINER_TOPIC)
@@ -35,8 +35,8 @@ class TrainerState:
                         self.propagated_weight_version = message.version
                     if isinstance(message, WeightBeingSavedToDisk):
                         self.version_weight_last_save = message.version
-                    if isinstance(message, OptimizerStepTrigger):
-                        self.processed_samples = message.version
+                    if isinstance(message, SamplesProcessed):
+                        self.samples_processed = message.samples_processed
 
         self._thread = threading.Thread(target=listen)
         self._thread.start()

--- a/pipelinerl/streams.py
+++ b/pipelinerl/streams.py
@@ -11,7 +11,6 @@ from typing import Any, Iterator, Literal, Self, TextIO
 import redis
 from pydantic import BaseModel
 import redis.exceptions
-from pipelinerl.finetune.types import PipelineBatchEncoding
 
 
 logger = logging.getLogger(__name__)
@@ -258,15 +257,13 @@ class FileStreamWriter(StreamWriter):
         if isinstance(data, BaseModel):
             # Convert Pydantic model to dict, handling tensors
             data_dict = data.model_dump()
-            # Convert any tensors to numpy arrays for JSON serialization
+            # Convert any torch.tensors to numpy arrays for JSON serialization
             for key, value in data_dict.items():
                 if hasattr(value, 'numpy'):
                     data_dict[key] = value.numpy()
-                elif hasattr(value, 'tolist'):
-                    data_dict[key] = value.tolist()
+                #elif hasattr(value, 'tolist'):
+                #    data_dict[key] = value.tolist()
             data = data_dict
-        elif isinstance(data, PipelineBatchEncoding):
-            data = {k: v.tolist() if hasattr(v, 'tolist') else v for k, v in data.items()}
         self._file.write(orjson.dumps(data, option=orjson.OPT_SERIALIZE_NUMPY).decode("utf-8"))
         self._file.write("\n")
         self._file.flush()

--- a/pipelinerl/streams.py
+++ b/pipelinerl/streams.py
@@ -256,6 +256,8 @@ class FileStreamWriter(StreamWriter):
         # Textual streams are so useful, that we try hard to jsonify the given object.
         if isinstance(data, BaseModel):
             data = data.model_dump()
+        elif hasattr(data, '__class__') and 'BatchEncoding' in str(type(data)):
+            data = {k: v.tolist() if hasattr(v, 'tolist') else v for k, v in data.items()}
         self._file.write(orjson.dumps(data, option=orjson.OPT_SERIALIZE_NUMPY).decode("utf-8"))
         self._file.write("\n")
         self._file.flush()

--- a/pipelinerl/streams.py
+++ b/pipelinerl/streams.py
@@ -11,6 +11,7 @@ from typing import Any, Iterator, Literal, Self, TextIO
 import redis
 from pydantic import BaseModel
 import redis.exceptions
+from pipelinerl.finetune.types import PipelineBatchEncoding
 
 
 logger = logging.getLogger(__name__)
@@ -264,7 +265,7 @@ class FileStreamWriter(StreamWriter):
                 elif hasattr(value, 'tolist'):
                     data_dict[key] = value.tolist()
             data = data_dict
-        elif hasattr(data, '__class__') and 'PipelineBatchEncoding' in str(type(data)):
+        elif isinstance(data, PipelineBatchEncoding):
             data = {k: v.tolist() if hasattr(v, 'tolist') else v for k, v in data.items()}
         self._file.write(orjson.dumps(data, option=orjson.OPT_SERIALIZE_NUMPY).decode("utf-8"))
         self._file.write("\n")

--- a/pipelinerl/streams.py
+++ b/pipelinerl/streams.py
@@ -261,8 +261,6 @@ class FileStreamWriter(StreamWriter):
             for key, value in data_dict.items():
                 if hasattr(value, 'numpy'):
                     data_dict[key] = value.numpy()
-                #elif hasattr(value, 'tolist'):
-                #    data_dict[key] = value.tolist()
             data = data_dict
         self._file.write(orjson.dumps(data, option=orjson.OPT_SERIALIZE_NUMPY).decode("utf-8"))
         self._file.write("\n")


### PR DESCRIPTION
  
<img width="352" alt="Screenshot 2025-07-04 at 3 58 43 PM" src="https://github.com/user-attachments/assets/bd2632e4-d7be-4569-99b6-f1f966b7be89" />

<img width="997" height="557" alt="Screenshot 2025-07-12 at 12 34 10 PM" src="https://github.com/user-attachments/assets/6f04ef67-790b-4c8b-b798-fe4892773a01" />


1. Batch Creation in Preprocessor (pipelinerl/preprocess.py)

  - Moved collation logic (collate and collate_packed) from fine-tuning to preprocessing stage
  - Preprocessor now outputs BatchEncoding objects instead of individual samples
  - Supports both standard batching and sequence packing modes
  - Implements per-worker sample tracking to ensure balanced data distribution

  2. Ring Buffer Implementation

  - Replaced list-based buffer with a deque-based ring buffer
  - Prevents unbounded memory growth when trainer is slower than preprocessor
  - Automatically discards old data when buffer is full, maintaining a sliding window of recent samples

  3. Trainer-Preprocessor Synchronization

  - Added bidirectional communication between trainer and preprocessor
  - Preprocessor reads trainer_status messages to track how many samples have been processed
  - Only sends new batches when trainer is ready (based on target_published_samples)
  - Prevents overwhelming the trainer with excessive queued data

  4. State Persistence

  - Added preprocessor_state.json to persist published samples count across restarts
  - Loads trainer's last processed sample count from training checkpoint
  - Ensures continuity when resuming training

  5. Debug and Monitoring Improvements

  - Added detailed per-worker sample tracking metrics
  - Enhanced logging for batch creation and worker synchronization
  - Better error handling with explicit re-raising for debugging

  Technical Details

  - Supports both standard batching and sequence packing modes
  - Maintains backward compatibility with existing training loop
  - Per-worker sample tracking ensures fair distribution across training GPUs
  - Thread-safe status reading using dedicated worker thread

Tests

- [x] `seq_packing=true` and `seq_packing=false` gives the same loss.
- [ ] Loss matches main.