### PR TITLE
vLLM-v0 upgrade: fixing multi-node training

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,9 @@ cd PipelineRL
 
 Create the environments with dependencies.
 ```bash
-conda create -n pipeline-rl -y python=3.11
+conda create -n pipeline-rl -y python=3.12
 conda run --no-capture-output -n pipeline-rl pip install -e .
-conda run --no-capture-output -n pipeline-rl pip install flash-attn==2.7.4.post1 --no-build-isolation
+conda run --no-capture-output -n pipeline-rl pip install flash-attn==2.8.3 --no-build-isolation
 ```
 
 Alternatively for `flash-attn`, you can install it via prebuilt packages (on Linux):
@@ -212,7 +212,7 @@ Alternatively for `flash-attn`, you can install it via prebuilt packages (on Lin
 # Check your PyTorch's C++ ABI setting first:
 # python -c "import torch; print(torch._C._GLIBCXX_USE_CXX11_ABI)"
 # Use cxx11abiTRUE or cxx11abiFALSE in the URL accordingly
-conda run --no-capture-output -n pipeline-rl pip install https://github.com/Dao-AILab/flash-attention/releases/download/v2.7.4.post1/flash_attn-2.7.4.post1+cu12torch2.6cxx11abiTRUE-cp311-cp311-linux_x86_64.whl
+conda run --no-capture-output -n pipeline-rl pip install https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu12torch2.7cxx11abiTRUE-cp312-cp312-linux_x86_64.whl
 ```
 
 By default Pipeline-RL will use the file system as the medium for streaming the generated data to the trainer processes. This works on one node, but the files can get quite large. To use Redis instead you will need to install the Redis server in the same conda environment:

--- a/conf/base.yaml
+++ b/conf/base.yaml
@@ -74,7 +74,7 @@ vllm_config:
     # V1 specific settings
     # logprobs-mode: processed_logprobs
     # V0 specific settings
-    num-scheduler-steps: 1
+    # num-scheduler-steps: 1
     disable-log-requests: ""
     disable-frontend-multiprocessing: ""
 
@@ -94,7 +94,6 @@ jobs: []
 
 eval_every_n_versions: 78000
 
-# changed
 model_path: Qwen/Qwen2.5-7B
 
 # will use default based on the chosen backend

--- a/conf/base.yaml
+++ b/conf/base.yaml
@@ -74,7 +74,6 @@ vllm_config:
     # V1 specific settings
     # logprobs-mode: processed_logprobs
     # V0 specific settings
-    # num-scheduler-steps: 1
     disable-log-requests: ""
     disable-frontend-multiprocessing: ""
 

--- a/pipelinerl/finetune/lora.py
+++ b/pipelinerl/finetune/lora.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 
 import torch
-from peft.mapping import get_peft_model
+from peft import get_peft_model
 from peft.peft_model import PeftModel
 from peft.tuners.lora import LoraConfig
 from peft.utils.other import prepare_model_for_kbit_training

--- a/pipelinerl/finetune_loop.py
+++ b/pipelinerl/finetune_loop.py
@@ -214,8 +214,9 @@ class WeightUpdateManager:
                 with deepspeed.zero.GatheredParameters([parameter]):
                     if get_accelerator().is_main_process:
                         # Use PyNcclCommunicator's broadcast method as torch.distributed does not work since vLLM disabled that transfer path
-                        # REVERTED: self.actor_update_group.broadcast(parameter.data, src=0, stream=torch.cuda.current_stream())
-                        dist.broadcast(parameter.data, src=0, group=self.actor_update_group)
+                        self.actor_update_group.broadcast(parameter.data, src=0, stream=torch.cuda.current_stream())
+                        # Previously used torch.distributed.broadcast
+                        # dist.broadcast(parameter.data, src=0, group=self.actor_update_group)
             if get_accelerator().is_main_process:
                 logger.info("Wait for HTTP requests")
                 for future in futures:  # type: ignore
@@ -258,9 +259,10 @@ class WeightUpdateManager:
                 logger.info(f"Published weight update request for version {version}")
                 for _, parameter in named_parameters.items():
                     # Use PyNcclCommunicator's broadcast method as torch.distributed does not work since vLLM disabled that transfer path
-                    # REVERTED: self.actor_update_group.broadcast(parameter.data, src=0, stream=torch.cuda.current_stream())
-                    dist.broadcast(parameter.data, src=0, group=self.actor_update_group)
-                dist.barrier(self.actor_update_group)
+                    self.actor_update_group.broadcast(parameter.data, src=0, stream=torch.cuda.current_stream())
+                    # Previously used torch.distributed.broadcast
+                    # dist.broadcast(parameter.data, src=0, group=self.actor_update_group)
+                # dist.barrier(self.actor_update_group)
                 for future in futures:
                     future.result()
                 logger.info("Finished broadcasting weights")
@@ -413,19 +415,19 @@ def run_finetuning_loop(
     get_accelerator().wait_for_everyone()
 
     if get_accelerator().is_main_process and args.send_weight_updates:
-        # current_device = get_accelerator().device
-        # torch.cuda.set_device(current_device)
-        # logger.info("Initializing actor process group using StatelessProcessGroup")
-        # logger.info(f"Set CUDA device to {current_device} for actor process group (rank 0)")
-        # actor_update_group = torch_utils.stateless_init_process_group(
-        logger.info("Initializing actor process group")
-        actor_update_group = torch_utils.init_extra_process_group(
-            group_name="actor",
-            backend="nccl",
+        current_device = get_accelerator().device
+        torch.cuda.set_device(current_device)
+        logger.info("Initializing actor process group using StatelessProcessGroup")
+        logger.info(f"Set CUDA device to {current_device} for actor process group (rank 0)")
+        actor_update_group = torch_utils.stateless_init_process_group(
+        # logger.info("Initializing actor process group")
+        # actor_update_group = torch_utils.init_extra_process_group(
+            # group_name="actor",
+            # backend="nccl",
             init_method=cfg.me.weight_update_group_init_method,
             rank=0,
             world_size=cfg.me.weight_update_group_world_size,
-            # device=current_device,
+            device=current_device,
         )
         logger.info("Actor process group initialized")
     else:
@@ -505,8 +507,8 @@ def run_finetuning_loop(
         if weight_update_manager is not None:
             weight_update_manager.shutdown()
         # PyNcclCommunicator doesn't need explicit destroy like torch.distributed process groups
-        if actor_update_group:
-            dist.destroy_process_group(actor_update_group)
+        # if actor_update_group:
+            # dist.destroy_process_group(actor_update_group)
 
 
 def rl_finetuning_worker(

--- a/pipelinerl/finetune_loop.py
+++ b/pipelinerl/finetune_loop.py
@@ -214,9 +214,8 @@ class WeightUpdateManager:
                 with deepspeed.zero.GatheredParameters([parameter]):
                     if get_accelerator().is_main_process:
                         # Use PyNcclCommunicator's broadcast method as torch.distributed does not work since vLLM disabled that transfer path
-                        self.actor_update_group.broadcast(parameter.data, src=0, stream=torch.cuda.current_stream())
                         # Previously used torch.distributed.broadcast
-                        # dist.broadcast(parameter.data, src=0, group=self.actor_update_group)
+                        self.actor_update_group.broadcast(parameter.data, src=0, stream=torch.cuda.current_stream())
             if get_accelerator().is_main_process:
                 logger.info("Wait for HTTP requests")
                 for future in futures:  # type: ignore
@@ -259,10 +258,10 @@ class WeightUpdateManager:
                 logger.info(f"Published weight update request for version {version}")
                 for _, parameter in named_parameters.items():
                     # Use PyNcclCommunicator's broadcast method as torch.distributed does not work since vLLM disabled that transfer path
-                    self.actor_update_group.broadcast(parameter.data, src=0, stream=torch.cuda.current_stream())
                     # Previously used torch.distributed.broadcast
-                    # dist.broadcast(parameter.data, src=0, group=self.actor_update_group)
-                # dist.barrier(self.actor_update_group)
+                    self.actor_update_group.broadcast(parameter.data, src=0, stream=torch.cuda.current_stream())
+                # No need for dist.barrier() here
+
                 for future in futures:
                     future.result()
                 logger.info("Finished broadcasting weights")
@@ -420,10 +419,6 @@ def run_finetuning_loop(
         logger.info("Initializing actor process group using StatelessProcessGroup")
         logger.info(f"Set CUDA device to {current_device} for actor process group (rank 0)")
         actor_update_group = torch_utils.stateless_init_process_group(
-        # logger.info("Initializing actor process group")
-        # actor_update_group = torch_utils.init_extra_process_group(
-            # group_name="actor",
-            # backend="nccl",
             init_method=cfg.me.weight_update_group_init_method,
             rank=0,
             world_size=cfg.me.weight_update_group_world_size,
@@ -506,9 +501,7 @@ def run_finetuning_loop(
     finally:
         if weight_update_manager is not None:
             weight_update_manager.shutdown()
-        # PyNcclCommunicator doesn't need explicit destroy like torch.distributed process groups
-        # if actor_update_group:
-            # dist.destroy_process_group(actor_update_group)
+        # PyNcclCommunicator doesn't need explicit destroy like destroy_process_group when using torch.distributed process groups
 
 
 def rl_finetuning_worker(

--- a/pipelinerl/torch_utils.py
+++ b/pipelinerl/torch_utils.py
@@ -1,10 +1,13 @@
+import datetime
 import logging
+import socket
 from datetime import timedelta
 from typing import Any, Optional, Union
 from urllib.parse import urlparse
 
 import torch
 import torch.distributed as dist
+from torch.distributed import TCPStore
 from torch.distributed.distributed_c10d import (
     Backend,
     PrefixStore,
@@ -19,6 +22,49 @@ from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
 from vllm.distributed.utils import StatelessProcessGroup
 
 logger = logging.getLogger(__name__)
+
+
+def _create_stateless_pg(host, port, rank, world_size):
+    """Create a StatelessProcessGroup that works across multiple nodes.
+
+    The upstream StatelessProcessGroup.create() binds its listening socket
+    to `host`, which fails in multi-node setups when `host` is a DNS name
+    that doesn't resolve to a local interface address (OSError: [Errno 99]
+    Cannot assign requested address).
+
+    We fix this by binding to 0.0.0.0 on rank 0 (accept connections on any
+    interface) while still passing the real hostname to TCPStore so that
+    non-rank-0 processes can connect to it.
+    """
+    launch_server = rank == 0
+    if launch_server:
+        listen_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listen_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        # Bind to all interfaces so it works regardless of hostname resolution
+        listen_socket.bind(("0.0.0.0", port))
+        listen_socket.listen()
+        listen_fd = listen_socket.fileno()
+    else:
+        listen_socket = None
+        listen_fd = None
+
+    store = TCPStore(
+        host_name=host,
+        port=port,
+        world_size=world_size,
+        is_master=launch_server,
+        timeout=datetime.timedelta(seconds=300),
+        use_libuv=False,
+        master_listen_fd=listen_fd,
+    )
+
+    return StatelessProcessGroup(
+        rank=rank,
+        world_size=world_size,
+        store=store,
+        socket=listen_socket,
+        data_expiration_seconds=3600,
+    )
 
 
 def stateless_init_process_group(init_method, rank, world_size, device):
@@ -41,7 +87,7 @@ def stateless_init_process_group(init_method, rank, world_size, device):
     master_port = parsed.port or 9000
     logger.debug(f"Parsed master_address: {master_address}, master_port: {master_port}")
 
-    pg = StatelessProcessGroup.create(
+    pg = _create_stateless_pg(
         host=master_address, port=master_port, rank=rank, world_size=world_size
     )
     pynccl = PyNcclCommunicator(pg, device=device)

--- a/pipelinerl/vllm0.py
+++ b/pipelinerl/vllm0.py
@@ -100,9 +100,6 @@ def make_worker_class(multi_step: bool):
             )
             # Use StatelessProcessGroup + PyNcclCommunicator for cross-process NCCL communication
             self.process_group = torch_utils.stateless_init_process_group(
-            # self.process_group = pipelinerl.torch_utils.init_extra_process_group(
-                # group_name="actor",
-                # backend="nccl",
                 init_method=weight_update_group_init_method,
                 rank=self.pg_rank,
                 world_size=weight_update_group_world_size,
@@ -118,9 +115,8 @@ def make_worker_class(multi_step: bool):
                 if target_dtype not in expected_dtypes:
                     logger.warning(f"Unexpected dtype for {info.name}: {info.dtype}")
                 buffer = torch.empty(tuple(info.shape), dtype=target_dtype, device=self.device)
-                self.process_group.broadcast(buffer, src=0, stream=torch.cuda.current_stream())
                 # Previously used torch.distributed.broadcast
-                # torch.distributed.broadcast(buffer, src=0, group=self.process_group)
+                self.process_group.broadcast(buffer, src=0, stream=torch.cuda.current_stream())
                 if VLLM_PRE_0_10 and isinstance(self.model_runner, MultiStepModelRunner):
                     loaded_params = self.model_runner._base_model_runner.model.load_weights(
                         weights=[(info.name, buffer)]

--- a/pipelinerl/vllm0.py
+++ b/pipelinerl/vllm0.py
@@ -2,7 +2,7 @@
 This module provides a custom vLLM inference server with dynamic weight updates using the legacy V0 engine architecture.
 
 Compatibility:
-    - vLLM versions <= 0.10.0 only
+    - vLLM versions < 0.11.0 only
     - Use vllm1.py for vLLM >= 0.11.0 as the V0 engine was removed in vLLM 0.11.0
 """
 from packaging import version as version_parser
@@ -11,12 +11,14 @@ import vllm
 # Check vLLM version compatibility
 vllm_version = version_parser.parse(vllm.__version__)
 
-if vllm_version > version_parser.parse("0.10.0"):
+if vllm_version >= version_parser.parse("0.11.0"):
     raise ImportError(
         f"pipelinerl.vllm0 is not compatible with vLLM {vllm.__version__}. "
         "This module only works with vLLM <= 0.10.0. "
         "Please use pipelinerl.vllm1 for vLLM >= 0.11.0 instead."
     )
+
+VLLM_PRE_0_10 = vllm_version < version_parser.parse("0.10.0")
 
 
 import asyncio
@@ -45,8 +47,12 @@ from vllm.executor.mp_distributed_executor import MultiprocessingDistributedExec
 from vllm.model_executor.layers.sampler import SamplerOutput
 from vllm.sequence import ExecuteModelRequest
 from vllm.usage.usage_lib import UsageContext
-from vllm.worker.multi_step_worker import MultiStepWorker
-from vllm.worker.multi_step_model_runner import MultiStepModelRunner
+if VLLM_PRE_0_10:
+    from vllm.worker.multi_step_worker import MultiStepWorker
+    from vllm.worker.multi_step_model_runner import MultiStepModelRunner
+else:
+    MultiStepWorker = None
+    MultiStepModelRunner = None
 
 
 from pipelinerl.finetune_loop import TrainerMessage, WeightUpdateRequest
@@ -66,6 +72,11 @@ logger.addHandler(handler)
 
 
 def make_worker_class(multi_step: bool):
+    if multi_step and not VLLM_PRE_0_10:
+        raise ImportError(
+            f"MultiStepWorker (num_scheduler_steps > 1) is not available in vLLM {vllm.__version__}. "
+            "It was removed in vLLM 0.10.0. Use --num-scheduler-steps 1."
+        )
     base_class = MultiStepWorker if multi_step else Worker
 
     class NewWorkerClass(base_class):
@@ -88,14 +99,14 @@ def make_worker_class(multi_step: bool):
                 + f"Weight update group init method: {weight_update_group_init_method}, world size: {weight_update_group_world_size}"
             )
             # Use StatelessProcessGroup + PyNcclCommunicator for cross-process NCCL communication
-            # self.process_group = torch_utils.stateless_init_process_group(
-            self.process_group = pipelinerl.torch_utils.init_extra_process_group(
-                group_name="actor",
-                backend="nccl",
+            self.process_group = torch_utils.stateless_init_process_group(
+            # self.process_group = pipelinerl.torch_utils.init_extra_process_group(
+                # group_name="actor",
+                # backend="nccl",
                 init_method=weight_update_group_init_method,
                 rank=self.pg_rank,
                 world_size=weight_update_group_world_size,
-                # device=self.device,
+                device=self.device,
             )
             logger.info(prefix + "Actor update process group initialized")
 
@@ -107,9 +118,10 @@ def make_worker_class(multi_step: bool):
                 if target_dtype not in expected_dtypes:
                     logger.warning(f"Unexpected dtype for {info.name}: {info.dtype}")
                 buffer = torch.empty(tuple(info.shape), dtype=target_dtype, device=self.device)
-                # self.process_group.broadcast(buffer, src=0, stream=torch.cuda.current_stream())
-                torch.distributed.broadcast(buffer, src=0, group=self.process_group)
-                if isinstance(self.model_runner, MultiStepModelRunner):
+                self.process_group.broadcast(buffer, src=0, stream=torch.cuda.current_stream())
+                # Previously used torch.distributed.broadcast
+                # torch.distributed.broadcast(buffer, src=0, group=self.process_group)
+                if VLLM_PRE_0_10 and isinstance(self.model_runner, MultiStepModelRunner):
                     loaded_params = self.model_runner._base_model_runner.model.load_weights(
                         weights=[(info.name, buffer)]
                     )
@@ -124,7 +136,7 @@ def make_worker_class(multi_step: bool):
 
 
 AsyncRLWorker = make_worker_class(multi_step=False)
-AsyncRLMultiStepWorker = make_worker_class(multi_step=True)
+AsyncRLMultiStepWorker = make_worker_class(multi_step=True) if VLLM_PRE_0_10 else None
 
 executor_lock = asyncio.Lock()
 
@@ -146,8 +158,9 @@ class WeightUpdateManager:
     def __init__(self, args, executor: AsyncRLExecutor):
         self.executor = executor
         self.driver_worker = getattr(executor, "driver_worker")
-        self.multi_step = args.num_scheduler_steps > 1
-        assert isinstance(self.driver_worker.worker, AsyncRLMultiStepWorker if self.multi_step else AsyncRLWorker)
+        self.multi_step = getattr(args, "num_scheduler_steps", 1) > 1
+        expected_cls = AsyncRLMultiStepWorker if self.multi_step else AsyncRLWorker
+        assert isinstance(self.driver_worker.worker, expected_cls)
         self.other_workers = getattr(executor, "workers")
         self.args = args
 
@@ -220,7 +233,12 @@ async def run_server(args, **uvicorn_kwargs) -> None:
     signal.signal(signal.SIGTERM, signal_handler)
 
     # Build the engine with the bespoke Executor and Worker classes
-    multi_step = args.num_scheduler_steps > 1
+    multi_step = getattr(args, "num_scheduler_steps", 1) > 1
+    if multi_step and not VLLM_PRE_0_10:
+        raise ImportError(
+            f"num_scheduler_steps > 1 is not supported in vLLM {vllm.__version__}. "
+            "MultiStepWorker was removed in vLLM 0.10.0. Use --num-scheduler-steps 1."
+        )
     engine_args = AsyncEngineArgs.from_cli_args(args)
     engine_config = engine_args.create_engine_config(UsageContext.OPENAI_API_SERVER)
     engine_config.parallel_config.distributed_executor_backend = AsyncRLExecutor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,32 +74,18 @@ ifeval = [
     "langdetect",
     "absl-py",
 ]
-terminalbench = [
-    "cube-standard[toolkit] @ file:///home/toolkit/cube-standard",
-    "cube-harness @ file:///home/toolkit/cube-harness",
-    "terminalbench-cube @ file:///home/toolkit/cube-harness/cubes/terminalbench-cube",
-]
 # Install all domain dependencies
 domains = [
     "pipelinerl[coding,fn_calling,logic,ifeval]",
 ]
 
 [tool.uv]
-conflicts = [
-    [{ extra = "terminalbench" }, { extra = "tapeagents" }],
-    [{ extra = "lora" }, { extra = "tapeagents" }],
-]
 # tapeagents==0.1.16 requires transformers<4.52 and accelerate<1.8, which conflict with the project's versions.
 # Overrides to allow resolution to proceed; tapeagents extra will be broken at runtime until it supports newer versions.
 override-dependencies = [
     "transformers>=4.51.0",
     "accelerate>=1.7.0",
 ]
-
-[tool.uv.sources]
-cube-standard = { path = "/home/toolkit/cube-standard", editable = true }
-cube-harness = { path = "/home/toolkit/cube-harness", editable = true }
-terminalbench-cube = { path = "/home/toolkit/cube-harness/cubes/terminalbench-cube", editable = true }
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "wheel",
     "numpy>=1.26.0",
     "packaging>=23.0",
-    "torch~=2.6.0",
+    "torch~=2.7.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -13,19 +13,18 @@ name = "pipelinerl"
 version = "0.1.0"
 description = "A scalable asynchronous reinforcement learning implementation with in-flight weight updates."
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = { file = "LICENSE" }
 authors = [
     { name = "ServiceNow" },
 ]
 dependencies = [
     "aiohttp>=3.9.0",
-    "vllm==0.8.5.post1",
+    "vllm==0.10.0",
     "accelerate==1.12.0",
-    "deepspeed==0.15.4",
-    "browsergym>=0.13.0",
+    "deepspeed~=0.18.0",
     "datasets>=2.21.0",
-    "transformers~=4.52.0" ,
+    "transformers~=4.57.0" ,
     "fastapi>=0.115.0",
     "joblib>=1.3.2",
     "jsonref>=1.1.0",
@@ -54,9 +53,12 @@ tapeagents = [
     "Tapeagents[finetune]==0.1.16",
 ]
 lora = [
-    "peft==0.18.0",
+    "peft~=0.18.0",
 ]
 # Domain-specific dependencies
+miniwob = [
+    "browsergym~=0.14.0",
+]
 coding = [
     "sandbox-fusion>=0.3.7",
 ]
@@ -72,10 +74,32 @@ ifeval = [
     "langdetect",
     "absl-py",
 ]
+terminalbench = [
+    "cube-standard[toolkit] @ file:///home/toolkit/cube-standard",
+    "cube-harness @ file:///home/toolkit/cube-harness",
+    "terminalbench-cube @ file:///home/toolkit/cube-harness/cubes/terminalbench-cube",
+]
 # Install all domain dependencies
 domains = [
     "pipelinerl[coding,fn_calling,logic,ifeval]",
 ]
+
+[tool.uv]
+conflicts = [
+    [{ extra = "terminalbench" }, { extra = "tapeagents" }],
+    [{ extra = "lora" }, { extra = "tapeagents" }],
+]
+# tapeagents==0.1.16 requires transformers<4.52 and accelerate<1.8, which conflict with the project's versions.
+# Overrides to allow resolution to proceed; tapeagents extra will be broken at runtime until it supports newer versions.
+override-dependencies = [
+    "transformers>=4.51.0",
+    "accelerate>=1.7.0",
+]
+
+[tool.uv.sources]
+cube-standard = { path = "/home/toolkit/cube-standard", editable = true }
+cube-harness = { path = "/home/toolkit/cube-harness", editable = true }
+terminalbench-cube = { path = "/home/toolkit/cube-harness/cubes/terminalbench-cube", editable = true }
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
A follow-up on #122 where vllm is upgraded from `v0.8.5.post1` to `v0.10.0`

The issue with multi-node training is fixed in this PR (see `_create_stateless_pg` in `torch_utils.py`), while other version upgrade changes are more or less the same as #122.

gray=`v0.8.5post1`, purple=`v0.10.0`, lightblue=`v0.10.0` on 2 nodes

| Logprobs | Reward |
|:--------:|:------:|
| <img width="485" height="250" alt="Logprobs" src="https://github.com/user-attachments/assets/760c55f9-2b71-47b7-a214-a96317f1f4bf" /> | <img width="363" height="250" alt="Rewards per optimization steps" src="https://github.com/user-attachments/assets/fd9b22e4-7ecb-436e-8ec9-78397b2278bd" /> |
 
 Full report is [here](https://wandb.ai/ehsk/watermelon/reports/ORZ-Qwen2-5-7B-vLLM-v0-upgrade-again---VmlldzoxNjU0MjQwMA).