### PR TITLE
Add `chat_template_kwargs` support

### DIFF
--- a/conf/math.yaml
+++ b/conf/math.yaml
@@ -22,12 +22,16 @@ vllm_config:
     max_model_len: 20000
 
 llm:
-  parameters: 
+  parameters:
     max_tokens: 16000
+  chat_template_kwargs:
+    enable_thinking: false
 
 test_llm:
-  parameters: 
+  parameters:
     max_tokens: 16000
+  chat_template_kwargs:
+    enable_thinking: false
 
 train_dataset_names:
 - open_reasoner_zero_57k

--- a/pipelinerl/actor.py
+++ b/pipelinerl/actor.py
@@ -818,6 +818,7 @@ def run_actor_loop(cfg: DictConfig):
             tokenizer_name=str(actor_model_path),
             parameters=cfg.llm.parameters,
             collect_logprobs=True,
+            chat_template_kwargs=cfg.llm.get("chat_template_kwargs", {}),
         )
         for url in llm_urls
     ]
@@ -828,6 +829,7 @@ def run_actor_loop(cfg: DictConfig):
             tokenizer_name=str(actor_model_path),
             parameters=cfg.test_llm.parameters,
             collect_logprobs=True,
+            chat_template_kwargs=cfg.test_llm.get("chat_template_kwargs", {}),
         )
         for url in llm_urls
     ]

--- a/pipelinerl/async_llm.py
+++ b/pipelinerl/async_llm.py
@@ -83,6 +83,9 @@ async def llm_async_generate(
             f"LLM parameters must serialize to a mapping, got {type(extra_parameters)}"
         )
 
+    if llm.chat_template_kwargs:
+        extra_parameters = {**extra_parameters, "chat_template_kwargs": _to_plain_obj(llm.chat_template_kwargs)}
+
     logger.debug(f"POST request to {llm.base_url}/v1/chat/completions")
 
     # Merge extra_parameters first so that data (model, messages, logprobs settings) takes precedence
@@ -198,19 +201,23 @@ def make_training_text(llm: TrainableLLM, llm_call: LLMCall) -> TrainingText:
             raise ValueError(f"Failed to process with vision-language processor: {e}")
     else:
         # Use tokenizer for text-only models
+        chat_kwargs = _to_plain_obj(llm.chat_template_kwargs) if llm.chat_template_kwargs else {}
         prompt_text = llm.tokenizer.apply_chat_template(
             conversation=llm_call.prompt.messages,
             tokenize=False,
             add_generation_prompt=True,
+            **chat_kwargs,
         )
         text = llm.tokenizer.apply_chat_template(
             full_messages,
             tokenize=False,
+            **chat_kwargs,
         )
         prompt_token_ids = llm.tokenizer.apply_chat_template(
             llm_call.prompt.messages,
             add_special_tokens=True,
             add_generation_prompt=True,
+            **chat_kwargs,
         )
 
     output_text = text[len(prompt_text) :]

--- a/pipelinerl/llm.py
+++ b/pipelinerl/llm.py
@@ -370,6 +370,7 @@ class TrainableLLM(LLM):
     max_parallel_requests: int = 32
     max_retries: int = 5
     base_delay: float = 0.5
+    chat_template_kwargs: dict = {}
     _semaphore: asyncio.Semaphore
 
     def model_post_init(self, __context):
@@ -549,12 +550,14 @@ class TrainableLLM(LLM):
             - Removes BOS token if present in the beginning of the text
         """
         self.load_tokenizer()
+        chat_kwargs = dict(self.chat_template_kwargs) if self.chat_template_kwargs else {}
         prompt_text = self.tokenizer.apply_chat_template(
-            conversation=prompt.messages, tokenize=False, add_generation_prompt=True
+            conversation=prompt.messages, tokenize=False, add_generation_prompt=True, **chat_kwargs
         )
         text = self.tokenizer.apply_chat_template(
             prompt.messages + [{"role": "assistant", "content": output.content}],
             tokenize=False,
+            **chat_kwargs,
         )
         output_text = text[len(prompt_text) :]
 
@@ -737,11 +740,12 @@ class TrainableLLM(LLM):
             headers |= {"Authorization": f"Bearer {self.api_token}"}
 
         time_t0 = time.time()
-        prompt_text = self.tokenizer.apply_chat_template(prompt.messages, tokenize=False)
+        chat_kwargs = dict(self.chat_template_kwargs) if self.chat_template_kwargs else {}
+        prompt_text = self.tokenizer.apply_chat_template(prompt.messages, tokenize=False, **chat_kwargs)
         completion = output.content or ""
         messages = prompt.messages + [{"role": "assistant", "content": completion}]
-        prompt_text = self.tokenizer.apply_chat_template(prompt.messages, tokenize=False, add_generation_prompt=True)
-        prompt_completion_text = self.tokenizer.apply_chat_template(messages, tokenize=False)
+        prompt_text = self.tokenizer.apply_chat_template(prompt.messages, tokenize=False, add_generation_prompt=True, **chat_kwargs)
+        prompt_completion_text = self.tokenizer.apply_chat_template(messages, tokenize=False, **chat_kwargs)
         if self.tokenizer.bos_token and prompt_text.startswith(self.tokenizer.bos_token):
             prompt_text = prompt_text[len(self.tokenizer.bos_token) :]
             prompt_completion_text = prompt_completion_text[len(self.tokenizer.bos_token) :]
@@ -843,7 +847,8 @@ class TrainableLLM(LLM):
                 return len(self.tokenizer(messages).input_ids)
             else:
                 add_generation_prompt = False if messages[-1]["role"] == "assistant" else True
-                return len(self.tokenizer.apply_chat_template(messages, add_generation_prompt=add_generation_prompt))
+                chat_kwargs = dict(self.chat_template_kwargs) if self.chat_template_kwargs else {}
+                return len(self.tokenizer.apply_chat_template(messages, add_generation_prompt=add_generation_prompt, **chat_kwargs))
         except Exception as e:
             if self.use_litellm_tokenizer_fallback:
                 logger.warning("Failed to count tokens with tokenizer, fallback to litellm counter")


### PR DESCRIPTION
Adds a `chat_template_kwargs` field to `TrainableLLM` that is forwarded to all `apply_chat_template` calls and to the
  vLLM `/v1/chat/completions` request body. This enables model-specific chat template parameters such as `enable_thinking: false` for Qwen3.