### PR TITLE
fix(fast-llm): stop producers and helpers on training completion

### DIFF
--- a/pipelinerl/launch.py
+++ b/pipelinerl/launch.py
@@ -705,6 +705,10 @@ def is_inference_process(proc: LaunchedProcess) -> bool:
     return proc.kind in {"actor_llm", "preprocessor_llm"}
 
 
+def is_finetune_process(proc: LaunchedProcess) -> bool:
+    return proc.kind == "finetune"
+
+
 def watch_processes_running(exp_path: Path, processes: List[LaunchedProcess], debug_mode: bool = False, use_fast_llm: bool = False, weight_broadcast: bool = True):
     if not debug_mode:
         trainer_state = TrainerState(exp_path, use_fast_llm=use_fast_llm, weight_broadcast=weight_broadcast)
@@ -719,6 +723,23 @@ def watch_processes_running(exp_path: Path, processes: List[LaunchedProcess], de
         for proc in processes:
             logger.info(f"Terminating {proc.handle.args}")
             terminate_with_children(proc.handle.pid)
+
+    def stop_alive_processes(alive: List[LaunchedProcess], reason: str):
+        logger.info(f"{reason}; stopping remaining {len(alive)} process(es): {[proc.kind for proc in alive]}")
+        for proc in list(alive):
+            logger.info(f"Terminating {proc.kind} process {proc.handle.args}")
+            terminate_with_children(proc.handle.pid)
+        for proc in list(alive):
+            proc.handle.wait()
+            logger.info(f"{proc.kind} process {proc.handle.args} stopped")
+            alive.remove(proc)
+
+    def wait_for_training_done_signal():
+        logger.info(
+            "Waiting for training completion signal "
+            f"(training_done={trainer_state.training_done})"
+        )
+        trainer_state.wait_for_training_done(timeout=5.0)
 
     logger.info("I have launched everyone, waiting for them to finish...")
 
@@ -741,21 +762,18 @@ def watch_processes_running(exp_path: Path, processes: List[LaunchedProcess], de
                     sys.exit(1)
                 logger.info(f"Process {proc.handle.args} finished cleanly")
                 alive.remove(proc)
-            if alive and all(is_inference_process(proc) for proc in alive):
+            if alive and trainer_state is not None and not any(is_finetune_process(proc) for proc in alive):
+                if not trainer_state.training_done:
+                    wait_for_training_done_signal()
+                    continue
+                stop_alive_processes(alive, "Trainer completion detected")
+            elif alive and all(is_inference_process(proc) for proc in alive):
                 # shut down inference servers after training is complete
                 if trainer_state is not None and not trainer_state.training_done:
                     # check if training is completed
-                    logger.info(f"Waiting for training completion signal (training_done={trainer_state.training_done})")
-                    trainer_state.wait_for_training_done(timeout=5.0)
+                    wait_for_training_done_signal()
                     continue
-                logger.info(f"Trainer completion detected; stopping remaining {len(alive)} inference server(s)")
-                for proc in list(alive):
-                    logger.info(f"Terminating inference server {proc.handle.args}")
-                    terminate_with_children(proc.handle.pid)
-                for proc in list(alive):
-                    proc.handle.wait()
-                    logger.info(f"Inference server {proc.handle.args} stopped")
-                    alive.remove(proc)
+                stop_alive_processes(alive, "Trainer completion detected")
             # TODO: make the watcdog code below more stable
             # if (trainer_state is not None
             #     and (version := trainer_state.propagated_weight_version is not None)

--- a/pipelinerl/preprocess.py
+++ b/pipelinerl/preprocess.py
@@ -485,6 +485,11 @@ def run_preprocessing_loop(
     final_train_steps = calculate_train_steps(cfg.finetune, cfg.finetune.interrupt_train_steps)
     samples_target = final_train_steps * cfg.finetune.train_batch_size * cfg.finetune.gradient_accumulation_passes
 
+    def is_trainer_finished() -> bool:
+        if cfg.use_fast_llm:
+            return trainer_state.training_done
+        return trainer_state.samples_processed is not None and trainer_state.samples_processed >= samples_target
+
     # Load published samples from state file
     llms = [
         TrainableLLM(
@@ -579,10 +584,7 @@ def run_preprocessing_loop(
                 num_filtered_out = 0
                 last_backpressure_log = 0.0
                 while True:
-                    if (
-                        trainer_state.samples_processed is not None
-                        and trainer_state.samples_processed >= samples_target
-                    ):
+                    if is_trainer_finished():
                         logger.info("Trainer signalled completion; stopping preprocessor loop")
                         break
                     llm = llms[next_llm_index] if llms else None

--- a/tests/test_launch_process_monitoring.py
+++ b/tests/test_launch_process_monitoring.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+from pipelinerl import launch
+
+
+class FakeTrainerState:
+    def __init__(self, exp_path: Path, use_fast_llm: bool, weight_broadcast: bool):
+        self.training_done = True
+        self.started = False
+
+    def start_listening(self):
+        self.started = True
+
+    def wait_for_training_done(self, timeout: float | None = None):
+        raise AssertionError("training_done was already set")
+
+
+class FakeProcessHandle:
+    def __init__(self, pid: int, kind: str, poll_results: list[int | None]):
+        self.pid = pid
+        self.args = [kind]
+        self._poll_results = poll_results
+        self.terminated = False
+        self.waited = False
+
+    def poll(self):
+        if self.terminated:
+            return -15
+        if self._poll_results:
+            return self._poll_results.pop(0)
+        return None
+
+    def wait(self):
+        self.waited = True
+        return -15 if self.terminated else 0
+
+
+def test_watch_processes_stops_remaining_helpers_after_training_completion(monkeypatch, tmp_path):
+    handles = {
+        100: FakeProcessHandle(100, "finetune", [0]),
+        101: FakeProcessHandle(101, "redis", [None]),
+        102: FakeProcessHandle(102, "actor", [None]),
+    }
+    terminated_pids = []
+
+    def terminate_with_children(pid: int):
+        terminated_pids.append(pid)
+        handles[pid].terminated = True
+
+    monkeypatch.setattr(launch, "TrainerState", FakeTrainerState)
+    monkeypatch.setattr(launch, "terminate_with_children", terminate_with_children)
+    monkeypatch.setattr(launch.time, "sleep", lambda seconds: None)
+
+    processes = [
+        launch.LaunchedProcess(kind="finetune", handle=handles[100]),
+        launch.LaunchedProcess(kind="redis", handle=handles[101]),
+        launch.LaunchedProcess(kind="actor", handle=handles[102]),
+    ]
+
+    launch.watch_processes_running(tmp_path, processes, use_fast_llm=True)
+
+    assert terminated_pids == [101, 102]
+    assert not handles[100].terminated
+    assert handles[101].waited
+    assert handles[102].waited


### PR DESCRIPTION
gpt-5 Codex note:

This is a fixup for PR #142. It extends the Fast-LLM early-stop fix beyond the actor path.

Changes:
- The preprocessor now uses the explicit Fast-LLM `training_finished` event before stopping, instead of the legacy sample-counting heuristic.
- The launcher now stops remaining supervised helper processes after the finetune process has exited cleanly and training completion has been observed. This covers redis/actor/preprocessor-style helpers, not only inference servers.

Why:
- In Fast-LLM mode, `samples_processed` reflects Redis entries read, not natural optimizer completion, so preprocessing could still stop converting actor rollouts into `fast_llm_streaming` documents too early.
- After a clean Fast-LLM completion, non-inference helper processes can otherwise keep the launcher alive even though the trainer has finished.

Verification from the local branch:
- `/Users/joel.lamy-poirier/Projects/Fast-LLM/venv/bin/python -m py_compile pipelinerl/launch.py pipelinerl/preprocess.py tests/test_launch_process_monitoring.py`
- `git diff --check`
- Targeted pytest collection is blocked in this local environment because `tests/conftest.py` imports `pipelinerl.vllm1`, which requires `uvloop`.
