### PR TITLE
Support WANDB_API_KEY_PATH for W&B logging

### DIFF
--- a/docs/FAST_LLM_INTEGRATION.md
+++ b/docs/FAST_LLM_INTEGRATION.md
@@ -337,6 +337,7 @@ Both submit launchers default to Denis's setup. Before running, override these e
 | `RESULTS_DIR` | `/mnt/shared/denis/math_7b_results` | Where outputs / checkpoints / logs land. Must be on a shared NFS readable by every node. |
 | `WANDB_ENTITY` | `denisko-se` | Your wandb entity (user or org). |
 | `WANDB_PROJECT` | `watermelon` | Your wandb project. |
+| `WANDB_API_KEY_PATH` | unset | Optional path to a file containing your wandb API key. |
 | `EAI_HOME_DATA` | `snow.home.denis_kocetkov` | Your EAI home data object (mounted at `/home/toolkit` inside the container). |
 | `EAI_SHARED_DATA` | `snow.research.afm.shared_fml` | Your shared NFS data object (mounted at `/mnt/shared`). |
 | `MODEL_PATH` | `/home/toolkit/Qwen2.5-7B` | Path to the base model checkpoint inside the container. |
@@ -360,7 +361,7 @@ Prereqs:
 
 1. Fast-LLM + PipelineRL installed in a shared venv — see [§3 End-to-end install → "Steps"](#3-end-to-end-install) above (clones both repos, checks out `gspo` and `fast-llm` branches, editable-installs).
 2. `eai` CLI authenticated. Run `eai login` once if it isn't already.
-3. Wandb credentials configured for the entity in `WANDB_ENTITY` (`~/.netrc` or `wandb login`).
+3. Wandb credentials configured for the entity in `WANDB_ENTITY`; set `WANDB_API_KEY_PATH` to a key file, or use `~/.netrc` / `wandb login`.
 4. The personalization env vars above exported (or edit the defaults in the script).
 5. A 7B base model checkpoint at the path `MODEL_PATH` points to (default `/home/toolkit/Qwen2.5-7B`).
 

--- a/pipelinerl/utils.py
+++ b/pipelinerl/utils.py
@@ -195,6 +195,14 @@ def get_environment_jobs(cfg: DictConfig, key: str | None = None) -> list[Job]:
     filtered = [job for job in env_jobs if getattr(job, "environment_key", None) == key]
     return filtered or env_jobs
 
+
+def _login_wandb_from_api_key_path() -> None:
+    api_key_path = os.environ.get("WANDB_API_KEY_PATH")
+    if api_key_path is None:
+        return
+    wandb.login(key=Path(api_key_path).read_text().strip())
+
+
 def init_wandb(
     cfg: DictConfig,
     run_dir: Path,
@@ -244,6 +252,7 @@ def init_wandb(
         logger.warning(f"wandb_name: {wandb_name} is longer than 128 characters. Truncating to 128 characters.")
 
     logging.info(f"Initializing W&B with\nname: {wandb_name[:128]}\nid: {wandb_id}\nresume: {resume}")
+    _login_wandb_from_api_key_path()
     run = wandb.init(
         name=wandb_name[:128],  # wandb limits name to 128 characters
         entity=cfg.wandb.wandb_entity_name,


### PR DESCRIPTION
gpt-5 Codex note:

## Summary
- Log in to W&B from the file pointed to by `WANDB_API_KEY_PATH` before PipelineRL calls `wandb.init`.
- Keep `WANDB_API_KEY` unnecessary for PipelineRL runs when a key file is available.
- Document `WANDB_API_KEY_PATH` in the Fast-LLM integration handover.

## Testing
- Not run. Change is limited to W&B credential initialization and docs.