### PR TITLE
Trainer-agnostic fixes extracted from the fast-llm branch

### DIFF
--- a/conf/finetune/base.yaml
+++ b/conf/finetune/base.yaml
@@ -33,6 +33,9 @@ train_batch_size: 1
 valid_batch_size: 4
 # Value of weight decay.
 weight_decay: 0.01
+# Adam optimizer betas (used by the adamw_torch / cpuadam optimizers).
+adam_beta1: 0.9
+adam_beta2: 0.999
 # Learning rate for training.
 learning_rate: 1e-6
 # How much to clip the gradient (no clipping if null)

--- a/pipelinerl/actor.py
+++ b/pipelinerl/actor.py
@@ -145,6 +145,7 @@ async def schedule_rollouts(
     samples_target = final_steps * cfg.finetune.train_batch_size * cfg.finetune.gradient_accumulation_passes
     retryable_rollout_exceptions = (
         aiohttp.ServerTimeoutError,
+        aiohttp.ServerDisconnectedError,
         asyncio.TimeoutError,
         TimeoutError,
         RetryableAbortedCompletionError,
@@ -192,21 +193,35 @@ async def schedule_rollouts(
                     break
                 except asyncio.CancelledError:
                     raise
-                except Exception as exc:
-                    is_retryable = isinstance(exc, retryable_rollout_exceptions)
-                    can_retry = max_rollout_retries < 0 or retry_count < max_rollout_retries
-                    if is_retryable and can_retry and not is_trainer_finished():
-                        retry_count += 1
-                        backoff_s = min(retry_max_delay_s, retry_initial_delay_s * (2 ** (retry_count - 1)))
-                        if retry_count == 1 or retry_count % 10 == 0:
-                            logger.warning(
-                                f"{scheduler_name}: rollout {group_id}/{rollout_index} failed with "
-                                f"{exc.__class__.__name__}, retry {retry_count}"
-                            )
-                        await asyncio.sleep(backoff_s)
-                        continue
-                    handle_rollout_exception(exc)
-                    return
+                except aiohttp.ClientResponseError as http_exc:
+                    if 400 <= http_exc.status < 500:
+                        logger.warning(
+                            f"Rollout failed with HTTP {http_exc.status} for group {group_id}, "
+                            f"skipping this rollout: {http_exc.message}"
+                        )
+                        rollout_result = RolloutResult(
+                            training_texts=[],
+                            metrics=BaseMetrics(reward=0.0, success=False, no_error=False, no_answer=True),
+                            latency=0.0,
+                        )
+                        break
+                    exc = http_exc
+                except Exception as exc_:
+                    exc = exc_
+                is_retryable = isinstance(exc, retryable_rollout_exceptions)
+                can_retry = max_rollout_retries < 0 or retry_count < max_rollout_retries
+                if is_retryable and can_retry and not is_trainer_finished():
+                    retry_count += 1
+                    backoff_s = min(retry_max_delay_s, retry_initial_delay_s * (2 ** (retry_count - 1)))
+                    if retry_count == 1 or retry_count % 10 == 0:
+                        logger.warning(
+                            f"{scheduler_name}: rollout {group_id}/{rollout_index} failed with "
+                            f"{exc.__class__.__name__}, retry {retry_count}"
+                        )
+                    await asyncio.sleep(backoff_s)
+                    continue
+                handle_rollout_exception(exc)
+                return
             rollout_result.model_version = model_version
             # Make a group id that will be different from groups made by another rollout maker
             full_group_id = f"{scheduler_name}_{group_id}"
@@ -219,10 +234,19 @@ async def schedule_rollouts(
                 sample.group_id = full_group_id
             group_rollouts[group_id].append(rollout_result)
             if len(group_rollouts[group_id]) == attempts:
-                # This is blocking call, but there's just one other thread reading from this queue.
-                random.shuffle(group_rollouts[group_id])
-                result_queue.put(group_rollouts[group_id])
+                # Filter out empty results (failed rollouts with no training data)
+                valid_results = [r for r in group_rollouts[group_id] if r.training_texts]
+                if not valid_results:
+                    logger.warning(
+                        f"Dropping group {group_id}: all {attempts} rollouts failed "
+                        f"(no training samples produced)"
+                    )
+                    del group_rollouts[group_id]
+                    finished_rollouts += 1
+                    return
+                random.shuffle(valid_results)
                 del group_rollouts[group_id]
+                await asyncio.get_event_loop().run_in_executor(None, result_queue.put, valid_results)
             finished_rollouts += 1
         except Exception as e:
             handle_rollout_exception(e)
@@ -589,8 +613,8 @@ class ActorLoop:
 
                 assert isinstance(rollout_results, list)
                 assert isinstance(rollout_results[0], RolloutResult)
-                assert len(rollout_results) == attempts, (
-                    f"Expected {attempts} rollouts, got {len(rollout_results)}"
+                assert 0 < len(rollout_results) <= attempts, (
+                    f"Expected 1-{attempts} rollouts, got {len(rollout_results)}"
                 )
                 group_samples = sum(len(r.training_texts) for r in rollout_results)
 

--- a/pipelinerl/async_llm.py
+++ b/pipelinerl/async_llm.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import io
 import logging
@@ -198,6 +199,11 @@ async def llm_async_generate(
     except Exception:
         logger.exception(f"Failed to parse llm response: {response_data}")
         raise
+
+    if finish_reason == "abort":
+        raise asyncio.TimeoutError(
+            f"vLLM aborted request (weight update in progress); will retry"
+        )
 
     output = LLMOutput(content=content or "")
     if raw_tool_calls:

--- a/pipelinerl/async_llm.py
+++ b/pipelinerl/async_llm.py
@@ -1,4 +1,3 @@
-import asyncio
 import base64
 import io
 import logging
@@ -199,11 +198,6 @@ async def llm_async_generate(
     except Exception:
         logger.exception(f"Failed to parse llm response: {response_data}")
         raise
-
-    if finish_reason == "abort":
-        raise asyncio.TimeoutError(
-            f"vLLM aborted request (weight update in progress); will retry"
-        )
 
     output = LLMOutput(content=content or "")
     if raw_tool_calls:

--- a/pipelinerl/domains/_datasets_compat.py
+++ b/pipelinerl/domains/_datasets_compat.py
@@ -1,0 +1,13 @@
+import inspect
+
+from datasets import load_dataset as _hf_load_dataset
+
+# `trust_remote_code` was removed from datasets>=4. Wrap load_dataset so callers can keep
+# passing it: forward it when the installed version accepts it, drop it otherwise.
+_LOAD_DATASET_ACCEPTS_TRUST_REMOTE_CODE = "trust_remote_code" in inspect.signature(_hf_load_dataset).parameters
+
+
+def load_dataset(*args, **kwargs):
+    if not _LOAD_DATASET_ACCEPTS_TRUST_REMOTE_CODE:
+        kwargs.pop("trust_remote_code", None)
+    return _hf_load_dataset(*args, **kwargs)

--- a/pipelinerl/domains/chartqa/load_datasets.py
+++ b/pipelinerl/domains/chartqa/load_datasets.py
@@ -1,19 +1,8 @@
-import inspect
 import logging
 from typing import List
 import datasets
-from datasets import load_dataset as _hf_load_dataset
 
-# `trust_remote_code` was removed from datasets>=4. Wrap load_dataset so callers can keep
-# passing it: forward it when the installed version accepts it, drop it otherwise.
-_LOAD_DATASET_ACCEPTS_TRUST_REMOTE_CODE = "trust_remote_code" in inspect.signature(_hf_load_dataset).parameters
-
-
-def load_dataset(*args, **kwargs):
-    if not _LOAD_DATASET_ACCEPTS_TRUST_REMOTE_CODE:
-        kwargs.pop("trust_remote_code", None)
-    return _hf_load_dataset(*args, **kwargs)
-
+from pipelinerl.domains._datasets_compat import load_dataset
 
 logger = logging.getLogger(__name__)
 

--- a/pipelinerl/domains/chartqa/load_datasets.py
+++ b/pipelinerl/domains/chartqa/load_datasets.py
@@ -1,7 +1,19 @@
+import inspect
 import logging
 from typing import List
 import datasets
-from datasets import load_dataset
+from datasets import load_dataset as _hf_load_dataset
+
+# `trust_remote_code` was removed from datasets>=4. Wrap load_dataset so callers can keep
+# passing it: forward it when the installed version accepts it, drop it otherwise.
+_LOAD_DATASET_ACCEPTS_TRUST_REMOTE_CODE = "trust_remote_code" in inspect.signature(_hf_load_dataset).parameters
+
+
+def load_dataset(*args, **kwargs):
+    if not _LOAD_DATASET_ACCEPTS_TRUST_REMOTE_CODE:
+        kwargs.pop("trust_remote_code", None)
+    return _hf_load_dataset(*args, **kwargs)
+
 
 logger = logging.getLogger(__name__)
 

--- a/pipelinerl/domains/math/load_datasets.py
+++ b/pipelinerl/domains/math/load_datasets.py
@@ -1,4 +1,3 @@
-import inspect
 import json
 import logging
 import random
@@ -8,18 +7,9 @@ from typing import Dict, Iterable, List, Sequence, Tuple
 
 import datasets
 import hydra
-from datasets import load_dataset as _hf_load_dataset
 from omegaconf import DictConfig
 
-# `trust_remote_code` was removed from datasets>=4. Wrap load_dataset so callers can keep
-# passing it: forward it when the installed version accepts it, drop it otherwise.
-_LOAD_DATASET_ACCEPTS_TRUST_REMOTE_CODE = "trust_remote_code" in inspect.signature(_hf_load_dataset).parameters
-
-
-def load_dataset(*args, **kwargs):
-    if not _LOAD_DATASET_ACCEPTS_TRUST_REMOTE_CODE:
-        kwargs.pop("trust_remote_code", None)
-    return _hf_load_dataset(*args, **kwargs)
+from pipelinerl.domains._datasets_compat import load_dataset
 
 """
 math_verify expects the following LaTeX format for the gold answer (with $ or \\boxed).

--- a/pipelinerl/domains/math/load_datasets.py
+++ b/pipelinerl/domains/math/load_datasets.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import logging
 import random
@@ -7,8 +8,18 @@ from typing import Dict, Iterable, List, Sequence, Tuple
 
 import datasets
 import hydra
-from datasets import load_dataset
+from datasets import load_dataset as _hf_load_dataset
 from omegaconf import DictConfig
+
+# `trust_remote_code` was removed from datasets>=4. Wrap load_dataset so callers can keep
+# passing it: forward it when the installed version accepts it, drop it otherwise.
+_LOAD_DATASET_ACCEPTS_TRUST_REMOTE_CODE = "trust_remote_code" in inspect.signature(_hf_load_dataset).parameters
+
+
+def load_dataset(*args, **kwargs):
+    if not _LOAD_DATASET_ACCEPTS_TRUST_REMOTE_CODE:
+        kwargs.pop("trust_remote_code", None)
+    return _hf_load_dataset(*args, **kwargs)
 
 """
 math_verify expects the following LaTeX format for the gold answer (with $ or \\boxed).

--- a/pipelinerl/finetune/optim.py
+++ b/pipelinerl/finetune/optim.py
@@ -22,11 +22,11 @@ def get_grouped_params(
     ]
 
 
-def get_optimizer(name, model, learning_rate, weight_decay):
+def get_optimizer(name, model, learning_rate, weight_decay, betas=(0.9, 0.999)):
     grouped_params = get_grouped_params(model, weight_decay)
     match name:
         case "adamw_torch":
-            optimizer = AdamW(grouped_params, lr=learning_rate)
+            optimizer = AdamW(grouped_params, lr=learning_rate, betas=betas)
         case "adafactor":
             optimizer = Adafactor(
                 grouped_params,
@@ -37,7 +37,7 @@ def get_optimizer(name, model, learning_rate, weight_decay):
         case "cpuadam":
             import deepspeed.ops.adam
 
-            optimizer = deepspeed.ops.adam.DeepSpeedCPUAdam(grouped_params, lr=learning_rate)
+            optimizer = deepspeed.ops.adam.DeepSpeedCPUAdam(grouped_params, lr=learning_rate, betas=betas)
         case "lion":
             optimizer = Lion(grouped_params, lr=learning_rate)
         case _:

--- a/pipelinerl/finetune_loop.py
+++ b/pipelinerl/finetune_loop.py
@@ -690,8 +690,11 @@ def rl_finetuning_worker(
         lag_stats["max_version"] = max(
             lag_stats.get("max_version", batch.model_version), batch.model_version
         )
-
         if not is_sentinel_batch:
+            # Sentinel batches carry the newest version, so they would bias the mean; exclude them.
+            lag_stats["sum_version"] = lag_stats.get("sum_version", 0) + batch.model_version
+            lag_stats["count"] = lag_stats.get("count", 0) + 1
+
             # We exclude time waiting for data from the pass time
             time_before_pass = time.time()
             training_metrics.passes += 1
@@ -881,6 +884,9 @@ def rl_finetuning_worker(
                     "stats/queue/batches": batch_queue.qsize(),
                     "stats/time_waiting_for_data": training_metrics.time_waiting_for_data,
                     "stats/lag": training_metrics.last_broadcasted_version - lag_stats["min_version"],
+                    "stats/lag_min": training_metrics.last_broadcasted_version - lag_stats["max_version"],
+                    "stats/lag_mean": training_metrics.last_broadcasted_version
+                    - lag_stats["sum_version"] / lag_stats["count"],
                     "throughput/tokens_perGPU_per_sec": this_worker_tokens / sum(passes_took) if passes_took else 0,
                     "throughput/tokens_per_step": this_worker_tokens * get_accelerator().state.num_processes,
                     "throughput/micro_batches_per_step": len(tokens_processed),

--- a/pipelinerl/finetune_loop.py
+++ b/pipelinerl/finetune_loop.py
@@ -883,10 +883,10 @@ def rl_finetuning_worker(
                     "stats/max_actor_version": lag_stats["max_version"],
                     "stats/queue/batches": batch_queue.qsize(),
                     "stats/time_waiting_for_data": training_metrics.time_waiting_for_data,
-                    "stats/lag": training_metrics.last_broadcasted_version - lag_stats["min_version"],
                     "stats/lag_min": training_metrics.last_broadcasted_version - lag_stats["max_version"],
                     "stats/lag_mean": training_metrics.last_broadcasted_version
                     - lag_stats["sum_version"] / lag_stats["count"],
+                    "stats/lag_max": training_metrics.last_broadcasted_version - lag_stats["min_version"],
                     "throughput/tokens_perGPU_per_sec": this_worker_tokens / sum(passes_took) if passes_took else 0,
                     "throughput/tokens_per_step": this_worker_tokens * get_accelerator().state.num_processes,
                     "throughput/micro_batches_per_step": len(tokens_processed),

--- a/pipelinerl/finetune_loop.py
+++ b/pipelinerl/finetune_loop.py
@@ -390,7 +390,9 @@ def run_finetuning_loop(
 
     logger.info(f"Using {'packed' if args.seq_packing else 'unpacked'} collate function")
 
-    optimizer = get_optimizer(args.optim, model, args.learning_rate, args.weight_decay)
+    optimizer = get_optimizer(
+        args.optim, model, args.learning_rate, args.weight_decay, betas=(args.adam_beta1, args.adam_beta2)
+    )
     lr_scheduler = get_scheduler(
         args.lr_scheduler_type,
         optimizer,

--- a/pipelinerl/launch.py
+++ b/pipelinerl/launch.py
@@ -117,7 +117,7 @@ def _get_quantization_args(cfg: DictConfig) -> list[str]:
     # consistent since the whole model then runs at that dtype.
     vllm_kwargs = cfg.vllm_config.get("vllm_kwargs") or {}
     dtype = vllm_kwargs.get("dtype")
-    if dtype not in (None, "auto", "bf16", "bfloat16"):
+    if dtype not in (None, "auto", "bfloat16"):
         return []
     return ["--quantization", "bf16_last_layer_fp32"]
 

--- a/pipelinerl/launch.py
+++ b/pipelinerl/launch.py
@@ -111,6 +111,14 @@ def _get_quantization_args(cfg: DictConfig) -> list[str]:
             f"vllm_config.quantization='{quantization}' is incompatible with PipelineRL's "
             "required FP32 lm_head inference path"
         )
+    # The bf16_last_layer_fp32 method forces a bf16 body with an fp32 lm_head, which overrides
+    # --dtype. When inference runs at a non-bf16 dtype (e.g. to match a fp16/fp32 trainer),
+    # skip it so vLLM honors the requested dtype; the fp32 lm_head is dropped, which is
+    # consistent since the whole model then runs at that dtype.
+    vllm_kwargs = cfg.vllm_config.get("vllm_kwargs") or {}
+    dtype = vllm_kwargs.get("dtype")
+    if dtype not in (None, "auto", "bf16", "bfloat16"):
+        return []
     return ["--quantization", "bf16_last_layer_fp32"]
 
 
@@ -155,7 +163,7 @@ def run_ref_llm(cfg: DictConfig, preprocessor_llm_idx: int, local_idx: int, gpus
     os.makedirs(log_dir, exist_ok=True)
 
     cmd = [
-        "python",
+        sys.executable,
         "-m",
         "vllm.entrypoints.openai.api_server",
         "--model",
@@ -202,7 +210,7 @@ def run_actor_llm(
     os.makedirs(log_dir, exist_ok=True)
     entrypoint = "pipelinerl.entrypoints.run_vllm1"
     cmd = [
-        "python",
+        sys.executable,
         "-m",
         entrypoint,
         "--model",
@@ -252,7 +260,7 @@ def run_actor(world_map: WorldMap, actor_idx: int, exp_dir: Path):
         raise NotImplementedError("Can only do 1 actor yet")
     llm_urls = "+".join(world_map.get_actor_urls())
     cmd = [
-        "python",
+        sys.executable,
         "-m",
         "pipelinerl.entrypoints.run_actor",
         "--config-dir",
@@ -276,7 +284,7 @@ def run_environment(cfg: DictConfig, job: Job):
     # run in a subprocess like in the rest of the code
     run_dir = Path(cfg.output_dir) / f"environment_{job.replica_idx}"
     cmd = [
-        "python",
+        sys.executable,
         "-m",
         "pipelinerl.entrypoints.run_environment",
         "--config-dir",
@@ -307,7 +315,7 @@ def run_finetune(cfg: DictConfig, world_map: WorldMap, gpus: list[int], exp_dir:
     if cfg.use_fsdp and cfg.use_deepspeed:
         raise ValueError("Cannot use both FSDP and DeepSpeed")
     cmd = [
-        "python",
+        sys.executable,
         "-m",
         "accelerate.commands.launch",
     ]
@@ -404,7 +412,7 @@ def run_preprocess(world_map: WorldMap, preprocessor_idx: int, exp_dir: Path):
         raise NotImplementedError("Can only do 1 preprocessor yet")
     llm_urls = "+".join(world_map.get_preprocessor_urls())
     cmd = [
-        "python",
+        sys.executable,
         "-m",
         "pipelinerl.entrypoints.run_preprocess",
         "--config-dir",
@@ -426,7 +434,11 @@ def run_preprocess(world_map: WorldMap, preprocessor_idx: int, exp_dir: Path):
 
 
 def run_redis(cfg: DictConfig):
-    # Launch redis-server
+    # Launch redis-server. Resolve paths to absolutes because redis-server
+    # chdir's to --dir before opening --logfile, which breaks relative paths.
+    output_dir = Path(cfg.output_dir).resolve()
+    redis_dir = output_dir / "redis"
+    os.makedirs(redis_dir, exist_ok=True)
     cmd = [
         "redis-server",
         "--bind",
@@ -434,11 +446,15 @@ def run_redis(cfg: DictConfig):
         "--port",
         str(cfg.streams.port),
         "--dir",
-        str(cfg.output_dir),
+        str(output_dir),
         "--protected-mode",
         "no",
         "--save",
         cfg.streams.save,
+        "--logfile",
+        str(redis_dir / "redis.log"),
+        "--loglevel",
+        "verbose",
     ]
     logger.info(f"Running redis with command: {' '.join(cmd)}")
     save_command(Path(cfg.output_dir) / "redis", cmd)

--- a/pipelinerl/launch.py
+++ b/pipelinerl/launch.py
@@ -232,6 +232,9 @@ def run_actor_llm(
     cmd.extend(_get_quantization_args(cfg))
 
     kwargs = _get_vllm_kwargs(cfg)
+    # vLLM v1 rejects num-scheduler-steps; defensively drop it.
+    if "num-scheduler-steps" in kwargs:
+        kwargs.pop("num-scheduler-steps")
     if kwargs:
         _append_vllm_kwargs(cmd, kwargs)
 
@@ -243,7 +246,9 @@ def run_actor_llm(
     save_command(log_dir, cmd)
     log_file_path = os.path.join(log_dir, "stdout.log")
     err_file_path = os.path.join(log_dir, "stderr.log")
-    env = {**os.environ, "CUDA_VISIBLE_DEVICES": gpu_str, **_get_quantization_env(cfg)}
+    # Give each actor a distinct base port so vLLM's get_open_port() race condition
+    # (TOCTOU: find-free-port then bind) doesn't cause EADDRINUSE when multiple servers start simultaneously.
+    env = {**os.environ, "CUDA_VISIBLE_DEVICES": gpu_str, "VLLM_PORT": str(30000 + actor_llm_idx * 20), **_get_quantization_env(cfg)}
     with open(log_file_path, "a") as log_file, open(err_file_path, "a") as err_file:
         proc = _popen(
             cmd,

--- a/pipelinerl/preprocess.py
+++ b/pipelinerl/preprocess.py
@@ -647,7 +647,7 @@ def run_preprocessing_loop(
                             write_micro_batch_slices(trainer_id, data_writer, batch_encoding, cfg.finetune.seq_parallel)
                             published_samples += len(batch_entries)
                             samples_per_trainer[trainer_id] += len(batch_entries)
-                            logger.debug(f"[inner loop] Packed microbatch with {len(batch_entries)} samples for trainer {trainer_id}")
+                            logger.debug(f"[inner loop] Unpacked microbatch with {len(batch_entries)} samples for trainer {trainer_id}")
                             trainer_id = (trainer_id + cfg.finetune.seq_parallel) % num_trainers
 
                         batch_done = published_samples == batch_boundary and trainer_id == 0

--- a/pipelinerl/preprocess.py
+++ b/pipelinerl/preprocess.py
@@ -637,8 +637,11 @@ def run_preprocessing_loop(
                                     current_length = 0
                                     logger.debug(f"[inner loop] Packed microbatch with {len(current_batch)} samples for trainer {trainer_id}")
                         else:
+                            # Unpacked path: need a full micro-batch before collating.
+                            if len(processed_entries_queue) < cfg.finetune.train_batch_size:
+                                break  # wait for more data; outer loop will refill the queue
                             batch_entries = []
-                            for _ in range(cfg.finetune.train_batch_size ):
+                            for _ in range(cfg.finetune.train_batch_size):
                                 batch_entries.append(processed_entries_queue.popleft())
                             batch_encoding = collate(batch_entries, tokenizer=tokenizer)
                             write_micro_batch_slices(trainer_id, data_writer, batch_encoding, cfg.finetune.seq_parallel)

--- a/pipelinerl/preprocess.py
+++ b/pipelinerl/preprocess.py
@@ -76,7 +76,7 @@ def _check_group_sizes(texts: list[dict], group_size: int) -> bool:
         group_rollouts[group_id].add(rollout_index)
 
     for group_id, rollout_ids in group_rollouts.items():
-        if len(rollout_ids) != group_size:
+        if not 1 <= len(rollout_ids) <= group_size:
             logger.error(f"Group sizes are wrong: {group_rollouts}")
             return False
 

--- a/pipelinerl/utils.py
+++ b/pipelinerl/utils.py
@@ -195,6 +195,14 @@ def get_environment_jobs(cfg: DictConfig, key: str | None = None) -> list[Job]:
     filtered = [job for job in env_jobs if getattr(job, "environment_key", None) == key]
     return filtered or env_jobs
 
+
+def _login_wandb_from_api_key_path() -> None:
+    api_key_path = os.environ.get("WANDB_API_KEY_PATH")
+    if api_key_path is None:
+        return
+    wandb.login(key=Path(api_key_path).read_text().strip())
+
+
 def init_wandb(
     cfg: DictConfig,
     run_dir: Path,
@@ -210,7 +218,14 @@ def init_wandb(
 
     python_env = {}
     for dist in distributions():
-        python_env[dist.metadata["Name"]] = dist.version
+        if dist.metadata is None:
+            continue
+        try:
+            name = dist.metadata["Name"]
+            if name is not None:
+                python_env[name] = dist.version
+        except Exception as e:
+            logger.warning(f"Accessing {dist} resulted in error {e}")
     config_for_wandb["python_env"] = python_env
 
     if cfg.wandb.wandb_resume == "always":
@@ -222,21 +237,29 @@ def init_wandb(
     else:
         raise ValueError(f"Unknown value for wandb_resume: {cfg.finetune.wandb_resume}")
 
-    wandb_name = str(run_dir)
+    run_path_name = str(run_dir)
     root = cfg.wandb.wandb_workspace_root
     if root:
-        if not wandb_name.startswith(root + "/"):
+        if not run_path_name.startswith(root + "/"):
             raise ValueError(f"run_dir {run_dir} does not start with root {root}")
-        wandb_name = wandb_name[len(root) + 1 :]
+        run_path_name = run_path_name[len(root) + 1 :]
+
+    # Display name: an explicit short name (with the component suffix, so the per-service runs
+    # stay distinguishable in a legend) when set, else the full root-relative run dir. The id
+    # stays derived from the unique run-dir path, so a short name may repeat across experiments
+    # without colliding.
+    component = run_path_name.rstrip("/").split("/")[-1]
+    wandb_name = f"{cfg.wandb.wandb_name}/{component}" if cfg.wandb.wandb_name else run_path_name
 
     wandb_id = cfg.wandb.wandb_id
     if not wandb_id:
-        wandb_id = wandb_name.replace("/", "_")
+        wandb_id = run_path_name.replace("/", "_")
 
     if len(wandb_name) > 128:
         logger.warning(f"wandb_name: {wandb_name} is longer than 128 characters. Truncating to 128 characters.")
 
     logging.info(f"Initializing W&B with\nname: {wandb_name[:128]}\nid: {wandb_id}\nresume: {resume}")
+    _login_wandb_from_api_key_path()
     run = wandb.init(
         name=wandb_name[:128],  # wandb limits name to 128 characters
         entity=cfg.wandb.wandb_entity_name,
@@ -493,6 +516,16 @@ def wait_for_environments(cfg: DictConfig):
 
 @contextlib.contextmanager
 def better_crashing(entrypoint_name: str):
+    import faulthandler
+    import signal
+
+    faulthandler.enable()  # dump the crashing thread's own stack on a fatal signal (SIGSEGV/SIGABRT/...)
+    if hasattr(signal, "SIGUSR1"):
+        # On-demand all-thread dump: `kill -USR1 <pid>` a process you suspect is hung.
+        # Do NOT arm faulthandler.dump_traceback_later(repeat=True): the periodic timer walks a
+        # running thread's frames without GIL synchronization and SIGSEGVs on Triton JIT
+        # kernel-launch frames (see https://github.com/ServiceNow/PipelineRL/issues/149).
+        faulthandler.register(signal.SIGUSR1, all_threads=True, chain=False)
     try:
         yield
     except Exception as e:

--- a/pipelinerl/world.py
+++ b/pipelinerl/world.py
@@ -57,7 +57,7 @@ class WorldMap:
         tp = llm_kwargs.get("tensor-parallel-size", 1)
         pp = llm_kwargs.get("pipeline-parallel-size", 1)
         self.gpus_per_llm = tp * pp
-        self.node_size = 8 if self.world_size > 1 else torch.cuda.device_count()
+        self.node_size = int(os.environ.get("GPUS_PER_NODE", torch.cuda.device_count()))
 
         place_inference_jobs = not cfg.debug.mode or cfg.debug.place_inference_workers
         if place_inference_jobs:


### PR DESCRIPTION
Trainer-agnostic fixes and improvements developed on the `fast-llm` integration branch (#140) but independent of the Fast-LLM trainer itself. Extracting them here so they can land on `main` on their own and shrink the integration PR.

_Description prepared with Claude Opus 4.8 (Claude Code)._

## Changes

- **`datasets>=4` compat** — a shared `load_dataset` wrapper (`pipelinerl/domains/_datasets_compat.py`) forwards `trust_remote_code` only when the installed `datasets` accepts it; imported by the chartqa + math loaders.
- **Config-drivable Adam betas** — `finetune.adam_beta1` / `adam_beta2` threaded through `get_optimizer` (`adamw_torch` / `cpuadam`).
- **Rollout robustness (`actor.py`)** — retry on `aiohttp.ServerDisconnectedError`; treat 4xx rollout responses as skip-not-retry (emit an empty result); drop groups whose rollouts all failed rather than publishing empties; offload the blocking result-queue `put` to an executor; accept `1..attempts` rollouts per group.
- **`preprocess.py`** — accept groups of `1..group_size` in the dataset loader's size check, so a skipped/dropped rollout no longer crashes preprocessing with `Invalid group sizes`; guard the unpacked-mode (`seq_packing=false`) `popleft` against a partial queue.
- **`launch.py`** — use `sys.executable` for subprocess launches; resolve an absolute redis `--dir` and add `--logfile` (redis `chdir`s to `--dir` before opening the logfile, so a relative path breaks); skip the `bf16_last_layer_fp32` quantization override when vLLM runs at a non-bf16 dtype; drop the vLLM-v1-rejected `num-scheduler-steps` kwarg; give each actor vLLM a distinct `VLLM_PORT` base to avoid `get_open_port()` port races.
- **`world.py`** — read `GPUS_PER_NODE` from the environment instead of hardcoding 8 for multi-node.
- **Logging & crash diagnostics** — optional `WANDB_API_KEY_PATH` login; resilient `python_env` collection (skips distributions with missing metadata); a component-suffixed W&B run name; on-demand `faulthandler` (SIGUSR1 all-thread dump, no periodic timer); log training lag as a `stats/lag_min` / `stats/lag_mean` / `stats/lag_max` trio instead of a single value.

## Notes

- Every change is trainer-agnostic and applies to the existing DeepSpeed / HTTP path.
- All touched files compile and the referenced config fields (`wandb.wandb_name`, `finetune.adam_beta*`) exist on `main`. **Not yet runtime-tested** — worth a quick smoke before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
