### PR TITLE
Log min/mean/max training lag

### DIFF
--- a/pipelinerl/finetune_loop.py
+++ b/pipelinerl/finetune_loop.py
@@ -690,8 +690,11 @@ def rl_finetuning_worker(
         lag_stats["max_version"] = max(
             lag_stats.get("max_version", batch.model_version), batch.model_version
         )
-
         if not is_sentinel_batch:
+            # Sentinel batches carry the newest version, so they would bias the mean; exclude them.
+            lag_stats["sum_version"] = lag_stats.get("sum_version", 0) + batch.model_version
+            lag_stats["count"] = lag_stats.get("count", 0) + 1
+
             # We exclude time waiting for data from the pass time
             time_before_pass = time.time()
             training_metrics.passes += 1
@@ -881,6 +884,9 @@ def rl_finetuning_worker(
                     "stats/queue/batches": batch_queue.qsize(),
                     "stats/time_waiting_for_data": training_metrics.time_waiting_for_data,
                     "stats/lag": training_metrics.last_broadcasted_version - lag_stats["min_version"],
+                    "stats/lag_min": training_metrics.last_broadcasted_version - lag_stats["max_version"],
+                    "stats/lag_mean": training_metrics.last_broadcasted_version
+                    - lag_stats["sum_version"] / lag_stats["count"],
                     "throughput/tokens_perGPU_per_sec": this_worker_tokens / sum(passes_took) if passes_took else 0,
                     "throughput/tokens_per_step": this_worker_tokens * get_accelerator().state.num_processes,
                     "throughput/micro_batches_per_step": len(tokens_processed),

--- a/pipelinerl/finetune_loop.py
+++ b/pipelinerl/finetune_loop.py
@@ -883,10 +883,10 @@ def rl_finetuning_worker(
                     "stats/max_actor_version": lag_stats["max_version"],
                     "stats/queue/batches": batch_queue.qsize(),
                     "stats/time_waiting_for_data": training_metrics.time_waiting_for_data,
-                    "stats/lag": training_metrics.last_broadcasted_version - lag_stats["min_version"],
                     "stats/lag_min": training_metrics.last_broadcasted_version - lag_stats["max_version"],
                     "stats/lag_mean": training_metrics.last_broadcasted_version
                     - lag_stats["sum_version"] / lag_stats["count"],
+                    "stats/lag_max": training_metrics.last_broadcasted_version - lag_stats["min_version"],
                     "throughput/tokens_perGPU_per_sec": this_worker_tokens / sum(passes_took) if passes_took else 0,
                     "throughput/tokens_per_step": this_worker_tokens * get_accelerator().state.num_processes,
                     "throughput/micro_batches_per_step": len(tokens_processed),


### PR DESCRIPTION
Claude Opus 4.8 note: authored by Claude, reviewed by @jlamypoirier.

Stacked on #151.

The old `stats/lag` reported `last_broadcasted_version - min_actor_version` — the staleness of the *oldest* sample in the batch, i.e. a max, but named as if it were the whole lag. This replaces it with an explicit min/mean/max trio:

- `stats/lag_min` = `last_broadcasted_version - max_actor_version` (newest sample)
- `stats/lag_mean` = `last_broadcasted_version - mean(model_version)` (batch mean)
- `stats/lag_max` = `last_broadcasted_version - min_actor_version` (oldest sample; == the former `stats/lag`)

Note: the bare `stats/lag` key is dropped in favor of `stats/lag_max`. Historical runs keep their logged `stats/lag` data; new runs log the trio instead.

The mean accumulates `model_version` over **non-sentinel** batches only: sentinel batches are created with the batch's newest version, so including them would bias the mean toward zero lag. Min/max are unaffected by sentinels (the sentinel version equals the real max, so it never moves either bound).

This makes the lag metric symmetric with the trainer-side staleness metrics, which already log mean/max/min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)