### PR TITLE
Name the Fast-LLM finetune wandb run from wandb_name

### DIFF
--- a/pipelinerl/launch.py
+++ b/pipelinerl/launch.py
@@ -444,10 +444,15 @@ def _run_finetune_fast_llm(cfg: DictConfig, world_map: WorldMap, gpus: list[int]
     if not include_callbacks:
         fast_llm_cfg.pop("callbacks", None)
 
-    # Derive experiment name for wandb from save_dir relative to workspace root.
+    # Derive experiment name for wandb: use the explicit run name (so the finetune run groups with
+    # the actor/preprocess runs, which init_wandb names `{wandb_name}/{component}`), falling back to
+    # the save_dir path relative to workspace root when no run name is set.
     root = cfg.wandb.wandb_workspace_root
     save_dir_str = str(save_dir)
-    experiment_name = save_dir_str[len(root) + 1:] if root and save_dir_str.startswith(root + "/") else save_dir.name
+    if cfg.wandb.wandb_name:
+        experiment_name = f"{cfg.wandb.wandb_name}/finetune"
+    else:
+        experiment_name = save_dir_str[len(root) + 1:] if root and save_dir_str.startswith(root + "/") else save_dir.name
 
     # Fill in all dynamic values so the saved config is fully functional.
     fast_llm_cfg["pretrained"]["path"] = cfg.model_path


### PR DESCRIPTION
_Claude Opus 4.8 (via Claude Code), on behalf of @joel-lamy-poirier._

### Problem
`_run_finetune_fast_llm` derives `experiment_name` from the run's `save_dir` and assigns it unconditionally:

```python
experiment_name = save_dir_str[len(root)+1:] if root and save_dir_str.startswith(root+"/") else save_dir.name
...
fast_llm_cfg["run"]["experiment_name"] = experiment_name
```

The Fast-LLM trainer names its own wandb run from `experiment_name`, so the finetune run always logs under the run-dir path (e.g. `pipelinerl_runs/pipelinerl_.../finetune`) and is **orphaned** from its sibling `actor`/`preprocess` runs, which `init_wandb` names `{wandb_name}/{component}`. It also silently overrides any `fast_llm.run.experiment_name` passed on the CLI.

### Fix
Prefer the explicit run name when set, so the finetune groups with actor/preprocess; otherwise keep the previous path-derived fallback.

```python
if cfg.wandb.wandb_name:
    experiment_name = f"{cfg.wandb.wandb_name}/finetune"
else:
    experiment_name = save_dir_str[len(root)+1:] if root and save_dir_str.startswith(root+"/") else save_dir.name
```

### Validation
Deployed to the cluster checkout and relaunched Fast-LLM (bf16 + fp16) runs: all finetune runs registered born-correct as `newvllm/fllm_*_sNN/finetune`, grouped with their actor/preprocess, with zero orphans. DeepSpeed path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)